### PR TITLE
JSON Parsing Issue

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -30,7 +30,9 @@
 	for (NSString *keyValuePair in [responseBody componentsSeparatedByString:@","]) {
 		NSArray *keyAndValue = [keyValuePair componentsSeparatedByString:@":"];
 		if (keyAndValue.count == 2) {
-			[jsonDict setObject:[keyAndValue objectAtIndex:1] forKey:[keyAndValue objectAtIndex:0]];
+                    NSString* k = [[keyAndValue objectAtIndex:0] stringByReplacingOccurrencesOfString:@" " withString:@""];
+                    k = [k stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+		    [jsonDict setObject:[keyAndValue objectAtIndex:1] forKey:k];
 		}
 	}
 	NSString *expiresIn = [jsonDict objectForKey:@"expires_in"];


### PR DESCRIPTION
When attempting to hit the foursquare API for an access token, we receive the following payload:

"{\n    \"access_token\":\"balskjdflaskdfjslakfjsaldfkj\"}"

This patch will trim the key value when it is pulled from the response so it can be later used as the aToken variable.
