### PR TITLE
Adding a persistence parameter

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -16,6 +16,8 @@
 #import "NXOAuth2ClientDelegate.h"
 #import "NXOAuth2ConnectionDelegate.h"
 
+extern NSString * const NXOAuth2ClientConnectionContextTokenRequest;
+extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
 
 @class NXOAuth2Connection, NXOAuth2AccessToken;
 
@@ -30,7 +32,9 @@
 //TODO: Link to documentation
 
 @interface NXOAuth2Client : NSObject <NXOAuth2ConnectionDelegate> {
-@private
+@protected
+	BOOL persistent;
+
 	NSString	*clientId;
 	NSString	*clientSecret;
 	
@@ -57,6 +61,11 @@
 
 @property (nonatomic, retain) NXOAuth2AccessToken	*accessToken;
 @property (nonatomic, assign) NSObject<NXOAuth2ClientDelegate>*	delegate;
+
+/*!
+ * If set to NO, the access token is not stored any keychain, will be removed if it was.
+ */
+@property (nonatomic, assign, readwrite, getter=isPersistent) BOOL persistent;
 
 /*!
  * Initializes the Client

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -72,18 +72,38 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 
 #pragma mark Accessors
 
-@synthesize clientId, clientSecret, userAgent, delegate;
+@synthesize clientId, clientSecret, userAgent, delegate, persistent, accessToken;
 
-@dynamic accessToken;
+- (void) setPersistent:(BOOL)shouldPersist;
+{
+	if (persistent == shouldPersist) return;
+	
+	if (shouldPersist && accessToken) {
+		[self.accessToken storeInDefaultKeychainWithServiceProviderName:[tokenURL host]];
+	}
+	
+	if (!shouldPersist) {
+		[self.accessToken removeFromDefaultKeychainWithServiceProviderName:[tokenURL host]];		
+	}
+	
+	[self willChangeValueForKey:@"persistent"];
+	persistent = shouldPersist;
+	[self didChangeValueForKey:@"persistent"];
+}
 
 - (NXOAuth2AccessToken *)accessToken;
 {
 	if (accessToken) return accessToken;
-	accessToken = [[NXOAuth2AccessToken tokenFromDefaultKeychainWithServiceProviderName:[tokenURL host]] retain];
-	if (accessToken) {
-		[delegate oauthClientDidGetAccessToken:self];
+	
+	if (persistent) {
+		accessToken = [[NXOAuth2AccessToken tokenFromDefaultKeychainWithServiceProviderName:[tokenURL host]] retain];
+		if (accessToken) {
+			[delegate oauthClientDidGetAccessToken:self];
+		}
+		return accessToken;
+	} else {
+		return nil;
 	}
-	return accessToken;
 }
 
 - (void)setAccessToken:(NXOAuth2AccessToken *)value;


### PR DESCRIPTION
This allows to create utility oauth clients that don’t push their tokens to the key chain.
As the persistence parameter defaults to `YES`, this should not affect existing clients.
However, I do recommend trying this on the iPhone before merging.
