### PR TITLE
Update project settings to use iOS 5.1 SDK

### DIFF
--- a/OAuth2Client.xcodeproj/project.pbxproj
+++ b/OAuth2Client.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 		F68B9A0613CDA5BC001CA749 /* NXOAuth2Request.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NXOAuth2Request.h; sourceTree = "<group>"; };
 		F6B39C6E13CC8A3200B43FE0 /* NXOAuth2Account.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NXOAuth2Account.h; sourceTree = "<group>"; };
 		F6B39C6F13CC8A3200B43FE0 /* NXOAuth2Account.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NXOAuth2Account.m; sourceTree = "<group>"; };
-		F6B39C7713CC980500B43FE0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		F6B39C7713CC980500B43FE0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		F6B39C7913CC981400B43FE0 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		F6CEFD8D13CDD83B00F19E55 /* NXOAuth2Request.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NXOAuth2Request.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.h
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.h
@@ -94,6 +94,7 @@ typedef void(^NXOAuth2PreparedAuthorizationURLHandler)(NSURL *preparedURL);
 - (void)requestAccessToAccountWithType:(NSString *)accountType;
 - (void)requestAccessToAccountWithType:(NSString *)accountType withPreparedAuthorizationURLHandler:(NXOAuth2PreparedAuthorizationURLHandler)aPreparedAuthorizationURLHandler;
 - (void)requestAccessToAccountWithType:(NSString *)accountType username:(NSString *)username password:(NSString *)password;
+- (void)requestAccessToAccountWithType:(NSString *)accountType username:(NSString *)username password:(NSString *)password desiredScope:(NSSet *)desiredScope;
 - (void)removeAccount:(NXOAuth2Account *)account;
 
 

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -196,6 +196,12 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     [client authenticateWithUsername:username password:password];
 }
 
+- (void)requestAccessToAccountWithType:(NSString *)accountType username:(NSString *)username password:(NSString *)password desiredScope:(NSSet *)desiredScope;
+{
+    NXOAuth2Client *client = [self pendingOAuthClientForAccountType:accountType];
+    client.desiredScope = desiredScope;
+    [client authenticateWithUsername:username password:password];
+}
 - (void)removeAccount:(NXOAuth2Account *)account;
 {
     if (account) {

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -175,7 +175,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             return nil;
         }
         
-        oauthAuthorizationHeader = [NSString stringWithFormat:@"OAuth %@", client.accessToken.accessToken];
+        oauthAuthorizationHeader = [NSString stringWithFormat:@"Bearer %@", client.accessToken.accessToken];
     }
     
     NSMutableURLRequest *startRequest = [request mutableCopy];
@@ -510,7 +510,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
     } else {
         // iOS 5 automaticaly strips the authorization 'token' from the header.
         // Thus we have to add the OAuth2 'token' again.
-        [mutableRequest setValue:[NSString stringWithFormat:@"OAuth %@", client.accessToken.accessToken]
+        [mutableRequest setValue:[NSString stringWithFormat:@"Bearer %@", client.accessToken.accessToken]
               forHTTPHeaderField:@"Authorization"];
     }
     return mutableRequest;


### PR DESCRIPTION
Since Xcode 4.4 does not come with iOS 5.0 SDK, only iOS 5.1 SDK, UIKit.framework in OAuth2Client.xcodeproj cannot be found by Xcode. This is fixed by changing the project settings to look for the framework in the iOS 5.1 SDK.
