### PR TITLE
Store the token_type for use in the auth headers

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccessToken.h
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.h
@@ -19,12 +19,14 @@
 @private
     NSString *accessToken;
     NSString *refreshToken;
+    NSString *tokenType;
     NSDate *expiresAt;
     NSSet *scope;
     NSString *responseBody;
 }
 @property (nonatomic, readonly) NSString *accessToken;
 @property (nonatomic, readonly) NSString *refreshToken;
+@property (nonatomic, readonly) NSString *tokenType;
 @property (nonatomic, readonly) NSDate *expiresAt;
 @property (nonatomic, readonly) BOOL doesExpire;
 @property (nonatomic, readonly) BOOL hasExpired;
@@ -36,7 +38,8 @@
 - (id)initWithAccessToken:(NSString *)accessToken;
 - (id)initWithAccessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken expiresAt:(NSDate *)expiryDate;
 - (id)initWithAccessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken expiresAt:(NSDate *)expiryDate scope:(NSSet *)scope;
-- (id)initWithAccessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken expiresAt:(NSDate *)expiryDate scope:(NSSet *)scope responseBody:(NSString *)responseBody; // designated
+- (id)initWithAccessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken expiresAt:(NSDate *)expiryDate scope:(NSSet *)scope responseBody:(NSString *)responseBody;
+- (id)initWithAccessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken expiresAt:(NSDate *)expiryDate scope:(NSSet *)scope responseBody:(NSString *)responseBody tokenType:(NSString*)tokenType; // designated
 
 
 #pragma mark Keychain Support

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -50,6 +50,7 @@
     NSString *anAccessToken = [jsonDict objectForKey:@"access_token"];
     NSString *aRefreshToken = [jsonDict objectForKey:@"refresh_token"];
     NSString *scopeString = [jsonDict objectForKey:@"scope"];
+    NSString *tokenType = [jsonDict objectForKey:@"token_type"];
     
     NSSet *scope = nil;
     if (scopeString) {
@@ -61,10 +62,11 @@
         expiryDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn integerValue]];
     }
     return [[[self class] alloc] initWithAccessToken:anAccessToken
-                                         refreshToken:aRefreshToken
-                                            expiresAt:expiryDate
-                                                scope:scope
-                                         responseBody:theResponseBody];
+                                        refreshToken:aRefreshToken
+                                           expiresAt:expiryDate
+                                               scope:scope
+                                        responseBody:theResponseBody
+                                           tokenType:tokenType];
 }
 
 - (id)initWithAccessToken:(NSString *)anAccessToken;
@@ -91,6 +93,16 @@
 
 - (id)initWithAccessToken:(NSString *)anAccessToken refreshToken:(NSString *)aRefreshToken expiresAt:(NSDate *)anExpiryDate scope:(NSSet *)aScope responseBody:(NSString *)aResponseBody;
 {
+    return [[[self class] alloc] initWithAccessToken:anAccessToken
+                                        refreshToken:aRefreshToken
+                                           expiresAt:anExpiryDate
+                                               scope:aScope
+                                        responseBody:aResponseBody
+                                           tokenType:nil];
+}
+
+- (id)initWithAccessToken:(NSString *)anAccessToken refreshToken:(NSString *)aRefreshToken expiresAt:(NSDate *)anExpiryDate scope:(NSSet *)aScope responseBody:(NSString *)aResponseBody tokenType:(NSString *)aTokenType
+{
     // a token object without an actual token is not what we want!
     NSAssert1(anAccessToken, @"No token from token response: %@", aResponseBody);
     if (anAccessToken == nil) {
@@ -104,6 +116,7 @@
         expiresAt    = [anExpiryDate copy];
         scope        = aScope ? [aScope copy] : [[NSSet alloc] init];
         responseBody = [aResponseBody copy];
+        tokenType    = [aTokenType copy];
     }
     return self;
 }
@@ -117,6 +130,21 @@
 @synthesize expiresAt;
 @synthesize scope;
 @synthesize responseBody;
+@synthesize tokenType;
+
+- (NSString*)tokenType
+{
+    if ([tokenType isEqualToString:@""]) {
+        //fall back on OAuth if token type not set
+        return @"OAuth";
+    } else if ([tokenType isEqualToString:@"bearer"]) {
+        //this is for out case sensitive server
+        //oauth server should be case insensitive so this should make no difference
+        return @"Bearer";
+    } else {
+        return tokenType;
+    }
+}
 
 - (BOOL)doesExpire;
 {

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -175,7 +175,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             return nil;
         }
         
-        oauthAuthorizationHeader = [NSString stringWithFormat:@"OAuth %@", client.accessToken.accessToken];
+        oauthAuthorizationHeader = [NSString stringWithFormat:@"%@ %@", client.accessToken.tokenType, client.accessToken.accessToken];
     }
     
     NSMutableURLRequest *startRequest = [request mutableCopy];
@@ -510,7 +510,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
     } else {
         // iOS 5 automaticaly strips the authorization 'token' from the header.
         // Thus we have to add the OAuth2 'token' again.
-        [mutableRequest setValue:[NSString stringWithFormat:@"OAuth %@", client.accessToken.accessToken]
+        [mutableRequest setValue:[NSString stringWithFormat:@"%@ %@", client.accessToken.tokenType, client.accessToken.accessToken]
               forHTTPHeaderField:@"Authorization"];
     }
     return mutableRequest;

--- a/Sources/OAuth2Client/NXOAuth2Request.m
+++ b/Sources/OAuth2Client/NXOAuth2Request.m
@@ -88,7 +88,7 @@
     }
     
     if (self.account) {
-        NSString *oauthAuthorizationHeader = [NSString stringWithFormat:@"OAuth %@", self.account.accessToken.accessToken];
+        NSString *oauthAuthorizationHeader = [NSString stringWithFormat:@"%@ %@", self.account.accessToken.tokenType, self.account.accessToken.accessToken];
         [request setValue:oauthAuthorizationHeader forHTTPHeaderField:@"Authorization"];
     }
     


### PR DESCRIPTION
Store the token_type sent from the server and re-use in signed requests.

If no toke sent (or the token is not stored) then fall back on using OAuth.
