### PR TITLE
Feature/assertion support

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccountStore.h
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.h
@@ -94,6 +94,7 @@ typedef void(^NXOAuth2PreparedAuthorizationURLHandler)(NSURL *preparedURL);
 - (void)requestAccessToAccountWithType:(NSString *)accountType;
 - (void)requestAccessToAccountWithType:(NSString *)accountType withPreparedAuthorizationURLHandler:(NXOAuth2PreparedAuthorizationURLHandler)aPreparedAuthorizationURLHandler;
 - (void)requestAccessToAccountWithType:(NSString *)accountType username:(NSString *)username password:(NSString *)password;
+- (void)requestAccessToAccountWithType:(NSString *)accountType assertionType:(NSURL *)assertionType assertion:(NSString *)assertion;
 - (void)removeAccount:(NXOAuth2Account *)account;
 
 

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -196,6 +196,12 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     [client authenticateWithUsername:username password:password];
 }
 
+- (void)requestAccessToAccountWithType:(NSString *)accountType assertionType:(NSURL *)assertionType assertion:(NSString *)assertion;
+{
+    NXOAuth2Client *client = [self pendingOAuthClientForAccountType:accountType];
+    [client authenticateWithAssertionType:assertionType assertion:assertion];
+}
+
 - (void)removeAccount:(NXOAuth2Account *)account;
 {
     if (account) {

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -111,6 +111,12 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
  */
 - (void)authenticateWithUsername:(NSString *)username password:(NSString *)password;
 
+/*!
+ * Authenticate with assertion (Assertion Flow)
+ */
+- (void)authenticateWithAssertionType:(NSURL *)assertionType assertion:(NSString *)assertion;
+
+
 #pragma mark Public
 
 - (void)requestAccess;

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -41,6 +41,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
     
     NSSet       *desiredScope;
     NSString    *userAgent;
+    NSString    *assertion;
     
     // server information
     NSURL        *authorizeURL;

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -258,6 +258,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (self.desiredScope) {
         [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
     }
+    
     authConnection = [[NXOAuth2Connection alloc] initWithRequest:tokenRequest
                                                requestParameters:parameters
                                                      oauthClient:self
@@ -294,6 +295,35 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     authConnection.context = NXOAuth2ClientConnectionContextTokenRequest;
 }
 
+// Assertion
+- (void)authenticateWithAssertionType:(NSURL *)assertionType assertion:(NSString *)assertion;
+{
+    NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
+    NSParameterAssert(assertionType);
+    NSParameterAssert(assertion);
+    
+    NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:tokenURL];
+    [tokenRequest setHTTPMethod:@"POST"];
+    [authConnection cancel];  // just to be sure
+    
+    self.authenticating = YES;
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                       @"assertion", @"grant_type",
+                                       clientId, @"client_id",
+                                       clientSecret, @"client_secret",
+                                       assertionType.absoluteString, @"assertion_type",
+                                       assertion, @"assertion",
+                                       nil];
+    if (self.desiredScope) {
+        [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
+    }
+    authConnection = [[NXOAuth2Connection alloc] initWithRequest:tokenRequest
+                                               requestParameters:parameters
+                                                     oauthClient:self
+                                                        delegate:self];
+    authConnection.context = NXOAuth2ClientConnectionContextTokenRequest;
+}
 
 #pragma mark Public
 


### PR DESCRIPTION
Add support for the `grant_type` `assertion` (read passing along credentials from other services such as Facebook. It is in accordance with [draft 10 spec section 4.1.2](http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-4.1.3).
