### PR TITLE
Feature/additional query params

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Account.m
+++ b/Sources/OAuth2Client/NXOAuth2Account.m
@@ -81,7 +81,8 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
             NSURL *authorizeURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAuthorizeURL];
             NSURL *tokenURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenURL];
             NSString *tokenType = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenType];
-            
+            NSDictionary *additionalQueryParams = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters];
+
             oauthClient = [[NXOAuth2Client alloc] initWithClientID:clientID
                                                       clientSecret:clientSecret
                                                       authorizeURL:authorizeURL
@@ -90,6 +91,10 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
                                                          tokenType:tokenType
                                                         persistent:NO
                                                           delegate:self];
+            if (additionalQueryParams) {
+                oauthClient.additionalAuthenticationParameters = additionalQueryParams;
+            }
+            
         }
     }
     return oauthClient;

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.h
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.h
@@ -36,6 +36,15 @@ extern NSString * const kNXOAuth2AccountStoreConfigurationScope;
 extern NSString * const kNXOAuth2AccountStoreConfigurationTokenType;
 
 
+/* 
+ * Requires a NSDictionary as a value.
+ * They are passed onto the authentication request as additional query parameters.
+ * The dictionary may not contain the keys "grant_type", "client_id", "client_secret",
+ * "username", "password", "redirect_uri", "code", "assertion_type" and "assertion" are not allowed.
+ */
+extern NSString * const kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters;
+
+
 #pragma mark Account Type
 
 extern NSString * const kNXOAuth2AccountStoreAccountType;

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -42,6 +42,7 @@ NSString * const kNXOAuth2AccountStoreConfigurationTokenURL = @"kNXOAuth2Account
 NSString * const kNXOAuth2AccountStoreConfigurationRedirectURL = @"kNXOAuth2AccountStoreConfigurationRedirectURL";
 NSString * const kNXOAuth2AccountStoreConfigurationScope = @"kNXOAuth2AccountStoreConfigurationScope";
 NSString * const kNXOAuth2AccountStoreConfigurationTokenType = @"kNXOAuth2AccountStoreConfigurationTokenType";
+NSString * const kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters = @"kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters";
 
 #pragma mark Account Type
 
@@ -382,6 +383,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
             NSURL *authorizeURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAuthorizeURL];
             NSURL *tokenURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenURL];
             NSString *tokenType = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenType];
+            NSDictionary *additionalAuthenticationParameters = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters];
             
             client = [[NXOAuth2Client alloc] initWithClientID:clientID
                                                  clientSecret:clientSecret
@@ -393,6 +395,11 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                      delegate:self];
             
             client.persistent = NO;
+            
+            if (additionalAuthenticationParameters != nil) {
+                NSAssert([additionalAuthenticationParameters isKindOfClass:[NSDictionary class]], @"additionalAuthenticationParameters have to be a NSDictionary");
+                client.additionalAuthenticationParameters = additionalAuthenticationParameters;
+            }
             
             if (scope != nil) {
                 client.desiredScope = scope;

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -62,12 +62,14 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
 @property (nonatomic, copy, readonly) NSString *clientId;
 @property (nonatomic, copy, readonly) NSString *clientSecret;
 @property (nonatomic, copy, readonly) NSString *tokenType;
+@property (nonatomic, strong, readwrite) NSDictionary *additionalAuthenticationParameters;
 
 @property (nonatomic, copy) NSSet *desiredScope;
 @property (nonatomic, copy) NSString *userAgent;
 
 @property (nonatomic, strong) NXOAuth2AccessToken    *accessToken;
 @property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ClientDelegate>*    delegate;
+
 
 /*!
  * If set to NO, the access token is not stored any keychain, will be removed if it was.

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -108,6 +108,26 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 @synthesize clientId, clientSecret, tokenType;
 @synthesize desiredScope, userAgent;
 @synthesize delegate, persistent, accessToken, authenticating;
+@synthesize additionalAuthenticationParameters;
+
+- (void)setAdditionalAuthenticationParameters:(NSDictionary *)value;
+{
+    if (value == additionalAuthenticationParameters) return;
+    
+    NSArray *forbiddenKeys = @[ @"grant_type", @"client_id",
+                                @"client_secret",
+                                @"username", @"password",
+                                @"redirect_uri", @"code",
+                                @"assertion_type", @"assertion" ];
+    
+    for (id key in value) {
+        NSAssert1([forbiddenKeys containsObject:key] == NO, @"The key %@ may not be used in additionalAuthenticationParameters", key);
+    }
+    
+    additionalAuthenticationParameters = value;
+    
+    
+}
 
 - (void)setPersistent:(BOOL)shouldPersist;
 {
@@ -203,6 +223,10 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                                        clientId, @"client_id",
                                        [redirectURL absoluteString], @"redirect_uri",
                                        nil];
+    
+    if (self.additionalAuthenticationParameters) {
+        [parameters addEntriesFromDictionary:self.additionalAuthenticationParameters];
+    }
     
     if (self.desiredScope.count > 0) {
         [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
@@ -322,6 +346,11 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (self.desiredScope) {
         [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
     }
+    
+    if (self.additionalAuthenticationParameters) {
+        [parameters addEntriesFromDictionary:self.additionalAuthenticationParameters];
+    }
+    
     authConnection = [[NXOAuth2Connection alloc] initWithRequest:tokenRequest
                                                requestParameters:parameters
                                                      oauthClient:self

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -121,7 +121,11 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                                 @"assertion_type", @"assertion" ];
     
     for (id key in value) {
-        NSAssert1([forbiddenKeys containsObject:key] == NO, @"The key %@ may not be used in additionalAuthenticationParameters", key);
+        if ([forbiddenKeys containsObject:key]) {
+            [[NSException exceptionWithName:NSInvalidArgumentException
+                                     reason:[NSString stringWithFormat:@"'%@' is not allowed as a key for additionalAuthenticationParameters", key]
+                                   userInfo:nil] raise];
+        }
     }
     
     additionalAuthenticationParameters = value;

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -321,6 +321,11 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (self.desiredScope) {
         [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
     }
+    
+    if (self.additionalAuthenticationParameters) {
+        [parameters addEntriesFromDictionary:self.additionalAuthenticationParameters];
+    }
+    
     authConnection = [[NXOAuth2Connection alloc] initWithRequest:tokenRequest
                                                requestParameters:parameters
                                                      oauthClient:self


### PR DESCRIPTION
Sending additional query parameters when first authenticating is useful so a lot of services. It is even required if you want to use [App.net](https://github.com/appdotnet/api-spec/blob/master/auth.md) in an app store approvable-way.
