### PR TITLE
Fixed crash on token JSON

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -67,7 +67,7 @@
     }
 
     NSDate *expiryDate = nil;
-    if (expiresIn) {
+    if (expiresIn != nil && expiresIn != [NSNull null]) {
         expiryDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn integerValue]];
     }
     return [[[self class] alloc] initWithAccessToken:anAccessToken


### PR DESCRIPTION
If `expires_in` in the JSON was null, the code would crash.
