### PR TITLE
CocoaPods' dependency is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ installation steps automatically.
 
 In order to install the library this way add the following line to your `Podfile`:
 
-```dependency 'NXOAuth2Client','1.2.2'```
+```pod 'NXOAuth2Client', '~> 1.2.2'```
 
 and run the following command `pod install`.
 


### PR DESCRIPTION
So just update to use this one: 

pod 'NXOAuth2Client', '~> 1.2.2'
