### PR TITLE
Adding explicit JSON media type to HTTP request header

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -197,6 +197,8 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         [startRequest setValue:client.userAgent forHTTPHeaderField:@"User-Agent"];
     }
     
+    [startRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    
     NSURLConnection *aConnection = [[NSURLConnection alloc] initWithRequest:startRequest delegate:self startImmediately:NO];    // don't start yet
     [aConnection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];    // let's first schedule it in the current runloop. (see http://github.com/soundcloud/cocoa-api-wrapper/issues#issue/2 )
     [aConnection start];    // now start


### PR DESCRIPTION
Some services (such as GitHub) respond to certain requests using the application/x-www-form-urlencoded media type, which causes an assertion failure as the library expects the response data to be of the JSON media type and cannot therefore deserialise the data.
