### PR TITLE
There doesn't seem to be a way to retrieve response data for when a connection fails

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -499,6 +499,12 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     NSString *body = [[NSString alloc] initWithData:connection.data encoding:NSUTF8StringEncoding];
     NSLog(@"oauthConnection Error: %@", body);
     
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
+    if (connection.data) {
+        [userInfo setObject:connection.data forKey:NXOAuth2ErrorResponseDataKey];
+    }
+    
+    NSError *updatedError = [NSError errorWithDomain:error.domain code:error.code userInfo:[NSDictionary dictionaryWithDictionary:userInfo]];
     
     if (connection == authConnection) {
         self.authenticating = NO;
@@ -539,7 +545,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
             }
             
             if ([delegate respondsToSelector:@selector(oauthClient:didFailToGetAccessTokenWithError:)]) {
-                [delegate oauthClient:self didFailToGetAccessTokenWithError:error];
+                [delegate oauthClient:self didFailToGetAccessTokenWithError:updatedError];
             }
         }
     }

--- a/Sources/OAuth2Client/NXOAuth2Constants.h
+++ b/Sources/OAuth2Client/NXOAuth2Constants.h
@@ -106,4 +106,4 @@ typedef enum  {
 
 
 extern NSString * const NXOAuth2AccountStoreErrorKey;
-
+extern NSString * const NXOAuth2ErrorResponseDataKey;

--- a/Sources/OAuth2Client/NXOAuth2Constants.m
+++ b/Sources/OAuth2Client/NXOAuth2Constants.m
@@ -38,3 +38,4 @@ NSString * const NXOAuth2HTTPErrorDomain = @"NXOAuth2HTTPErrorDomain";
 #pragma mark UserInfo Keys
 
 NSString * const NXOAuth2AccountStoreErrorKey = @"NXOAuth2AccountStoreErrorKey";
+NSString * const NXOAuth2ErrorResponseDataKey = @"NXOAuth2ErrorResponseDataKey";


### PR DESCRIPTION
In the app that I'm developing, on connection fail I need a way to access the response data to know what error message to display.  

This is my addition to the library to bypass the issue.  Alternatively if there exist a way to do so in the current version, would be great if you can point me in the right direction.  Appreciate it!
