### PR TITLE
Support redirect URLs without a scheme specified

### DIFF
--- a/Sources/NSURL+NXOAuth2.m
+++ b/Sources/NSURL+NXOAuth2.m
@@ -37,7 +37,16 @@
 
 - (NSString *)nxoauth2_valueForQueryParameterKey:(NSString *)key;
 {
-    NSString *queryString = [self query];
+    //self may not contain a scheme
+    //for instance Google API redirect url may look like urn:ietf:wg:oauth:2.0:oob
+    //NSURL requires a valid scheme or query will return nil
+    NSString *absoluteString = self.absoluteString;
+    if ([absoluteString rangeOfString:@"://"].location == NSNotFound) {
+        absoluteString = [NSString stringWithFormat:@"http://%@", absoluteString];
+    }    
+    NSURL *qualifiedURL = [NSURL URLWithString:absoluteString];
+    
+    NSString *queryString = [qualifiedURL query];
     NSDictionary *parameters = [queryString nxoauth2_parametersFromEncodedQueryString];
     return [parameters objectForKey:key];
 }


### PR DESCRIPTION
Support redirect URLs without a scheme specified, such as redirect URLs used by Google APIs. Google API redirect URLs may look like "urn:ietf:wg:oauth:2.0:oob". However, NSURL will return nil for the query portion if the URL has no scheme.
