### PR TITLE
Dirty fix for oauth with LinkedIn, which requires full request URI in PO...

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -307,11 +307,8 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 {
     NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
     
-    NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:tokenURL];
-    [tokenRequest setHTTPMethod:@"POST"];
-    [authConnection cancel];  // just to be sure
+    
 
-    self.authenticating = YES;
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                        @"authorization_code", @"grant_type",
@@ -320,6 +317,22 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                                        [redirectURL absoluteString], @"redirect_uri",
                                        authGrant, @"code",
                                        nil];
+    
+    NSString *url = tokenURL.absoluteString;
+    url = [url stringByAppendingString:@"?"];
+    for(id key in parameters) {
+        url = [url stringByAppendingString:key];
+        url = [url stringByAppendingString:@"="];
+        url = [url stringByAppendingString:[parameters objectForKey:key]];
+        url = [url stringByAppendingString:@"&"];
+    }
+        
+    NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
+    [tokenRequest setHTTPMethod:@"POST"];
+    [authConnection cancel];  // just to be sure
+    
+    self.authenticating = YES;
+    
     if (self.desiredScope) {
         [parameters setObject:[[self.desiredScope allObjects] componentsJoinedByString:@" "] forKey:@"scope"];
     }


### PR DESCRIPTION
Dirty fix for oauth with LinkedIn (https://developer.linkedin.com/documents/authentication, probably others), which requires full request URI in POST for auth token. This is ugly code but it works and I think you will fix it somehow. It's okay to decline it.
