### PR TITLE
NSAssert failure when refresh_token is not used and access_token is expired

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -426,7 +426,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 
 #pragma mark Public
 
-- (void)refreshAccessToken;
+- (void)refreshAccessToken
 {
     [self refreshAccessTokenAndRetryConnection:nil];
 }

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -165,7 +165,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         // if token is expired don't bother starting this connection.
         NSDate *tenSecondsAgo = [NSDate dateWithTimeIntervalSinceNow:(-10)];
         NSDate *tokenExpiresAt = client.accessToken.expiresAt;
-        if ([tenSecondsAgo earlierDate:tokenExpiresAt] == tokenExpiresAt) {
+        if (nil != client.accessToken.refreshToken && [tenSecondsAgo earlierDate:tokenExpiresAt] == tokenExpiresAt) {
             [self cancel];
             [client refreshAccessTokenAndRetryConnection:self];
             return nil;


### PR DESCRIPTION
I have found an issue if refresh_token is not used by OAuth2 server and access_token is expired or is about to expire (10 seconds to expire).

The issue causes application to crash on NSAssert in NXOAuth2Client.m, because method refreshAccessTokenAndRetryConnection requires to pass access_token together with refresh_token.

According to OAuth2 specification, the refresh_token is optional.

Related code where assertion fails if refresh_token is empty:

``` objc
- (void)refreshAccessTokenAndRetryConnection:(NXOAuth2Connection *)retryConnection;
{
    // <cut> 

    if (!authConnection) {
        NSAssert((accessToken.refreshToken != nil), @"invalid state");
```
