### PR TITLE
redirectURL nil check added for handleRedirectURL

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -168,7 +168,8 @@
 
 - (BOOL)hasExpired;
 {
-    return ([[NSDate date] earlierDate:expiresAt] == expiresAt);
+    // give it a little buffer to expire date
+    return ([[NSDate dateWithTimeIntervalSinceNow:10] earlierDate:expiresAt] == expiresAt);
 }
 
 - (NSString *)description;

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -343,7 +343,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
         accountTypes = [self.configurations keysOfEntriesPassingTest:^(id key, id obj, BOOL *stop) {
             NSDictionary *configuration = obj;
             NSURL *redirectURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationRedirectURL];
-            if ( [[[aURL absoluteString] lowercaseString] hasPrefix:[[redirectURL absoluteString] lowercaseString]]) {
+            if (redirectURL != nil && [[[aURL absoluteString] lowercaseString] hasPrefix:[[redirectURL absoluteString] lowercaseString]]) {
                 
                 // WORKAROUND: The URL which is passed to this method may be lower case also the scheme is registered in camel case. Therefor replace the prefix with the stored redirectURL.
                 if (fixedRedirectURL == nil) {

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -305,7 +305,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 // Web Server Flow only
 - (void)requestTokenWithAuthGrant:(NSString *)authGrant redirectURL:(NSURL *)redirectURL;
 {
-    NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
+    //NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
     
     NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:tokenURL];
     [tokenRequest setHTTPMethod:@"POST"];
@@ -338,7 +338,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 // Client Credential Flow
 - (void)authenticateWithClientCredentials;
 {
-    NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
+    //NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
     
     NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:tokenURL];
     [tokenRequest setHTTPMethod:@"POST"];
@@ -364,7 +364,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 // User Password Flow Only
 - (void)authenticateWithUsername:(NSString *)username password:(NSString *)password;
 {
-    NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
+    //NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
     
     NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:tokenURL];
     [tokenRequest setHTTPMethod:@"POST"];
@@ -397,7 +397,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 // Assertion
 - (void)authenticateWithAssertionType:(NSURL *)anAssertionType assertion:(NSString *)anAssertion;
 {
-    NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
+    //NSAssert1(!authConnection, @"authConnection already running with: %@", authConnection);
     NSParameterAssert(anAssertionType);
     NSParameterAssert(anAssertion);
     

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -225,14 +225,18 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         && [httpMethod caseInsensitiveCompare:@"PUT"] != NSOrderedSame) {
         aRequest.URL = [aRequest.URL nxoauth2_URLByAddingParameters:parameters];
     } else {
-        NSInputStream *postBodyStream = [[NXOAuth2PostBodyStream alloc] initWithParameters:parameters];
+        /*NSInputStream *postBodyStream = [[NXOAuth2PostBodyStream alloc] initWithParameters:parameters];
         
         NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", [(NXOAuth2PostBodyStream *)postBodyStream boundary]];
         NSString *contentLength = [NSString stringWithFormat:@"%lld", [(NXOAuth2PostBodyStream *)postBodyStream length]];
         [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
         [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
         
-        [aRequest setHTTPBodyStream:postBodyStream];
+        [aRequest setHTTPBodyStream:postBodyStream];*/
+        
+        NSString *contentType = @"application/x-www-form-urlencoded";
+        [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
+        [aRequest setHTTPBody:[[NSString nxoauth2_stringWithEncodedQueryParameters:parameters] dataUsingEncoding:NSUTF8StringEncoding]];
     }
 }
 

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -164,9 +164,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         ![[requestParameters objectForKey:@"grant_type"] isEqualToString:@"refresh_token"]) {
         
         // if token is expired don't bother starting this connection.
-        NSDate *tenSecondsAgo = [NSDate dateWithTimeIntervalSinceNow:(-10)];
-        NSDate *tokenExpiresAt = client.accessToken.expiresAt;
-        if ([tenSecondsAgo earlierDate:tokenExpiresAt] == tokenExpiresAt) {
+        if (client.accessToken.hasExpired) {
             [self cancel];
             [client refreshAccessTokenAndRetryConnection:self];
             return nil;

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -227,17 +227,20 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         aRequest.URL = [aRequest.URL nxoauth2_URLByAddingParameters:parameters];
     } else {
         /*NSInputStream *postBodyStream = [[NXOAuth2PostBodyStream alloc] initWithParameters:parameters];
-        
-        NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", [(NXOAuth2PostBodyStream *)postBodyStream boundary]];
-        NSString *contentLength = [NSString stringWithFormat:@"%lld", [(NXOAuth2PostBodyStream *)postBodyStream length]];
-        [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
-        [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
-        
-        [aRequest setHTTPBodyStream:postBodyStream];*/
+         
+         NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", [(NXOAuth2PostBodyStream *)postBodyStream boundary]];
+         NSString *contentLength = [NSString stringWithFormat:@"%lld", [(NXOAuth2PostBodyStream *)postBodyStream length]];
+         [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
+         [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
+         
+         [aRequest setHTTPBodyStream:postBodyStream];*/
         
         NSString *contentType = @"application/x-www-form-urlencoded";
+        NSString *content = [NSString nxoauth2_stringWithEncodedQueryParameters:parameters];
+        NSString *contentLength = [NSString stringWithFormat:@"%d", content.length];
         [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
-        [aRequest setHTTPBody:[[NSString nxoauth2_stringWithEncodedQueryParameters:parameters] dataUsingEncoding:NSUTF8StringEncoding]];
+        [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
+        [aRequest setHTTPBody:[content dataUsingEncoding:NSUTF8StringEncoding]];
     }
 }
 

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -11,6 +11,7 @@
 //  the full licence.
 //
 
+#import "NSString+NXOAuth2.h"
 #import "NSURL+NXOAuth2.h"
 #import "NSData+NXOAuth2.h"
 


### PR DESCRIPTION
It throws nil exception when you have multiple account stores with and
without redirectURL. Nil check must be performed to prevent exception.
