### PR TITLE
Remove 64 bits warnings

### DIFF
--- a/OAuth2Client.xcodeproj/project.pbxproj
+++ b/OAuth2Client.xcodeproj/project.pbxproj
@@ -53,7 +53,6 @@
 		942FFD7E12315EFF00E6C65E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E5AC92122C097B00C7021A /* Security.framework */; };
 		945A500D123F7BAE00A6F2EB /* NXOAuth2ClientDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 824D5A6D123F68A8001177D5 /* NXOAuth2ClientDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94B6CE7219C1D3E400AA859B /* NXOAuth2PostBodyStreamSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 94B6CE7119C1D3E400AA859B /* NXOAuth2PostBodyStreamSpec.m */; };
-		94B6CE8119C1EECC00AA859B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94B6CE8019C1EECC00AA859B /* Info.plist */; };
 		94CCDD2219C1F29E00F9F148 /* libOAuth2Client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2AAC07E0554694100DB518D /* libOAuth2Client.a */; };
 		94E5AC93122C097B00C7021A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E5AC92122C097B00C7021A /* Security.framework */; };
 		99D8A7F913852C6E00E3073C /* NSData+NXOAuth2.h in Headers */ = {isa = PBXBuildFile; fileRef = 99D8A7F713852C6E00E3073C /* NSData+NXOAuth2.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -414,7 +413,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = nxtbgthng;
 				TargetAttributes = {
 					94B6CE6519C1D0A200AA859B = {
@@ -456,7 +455,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94B6CE8119C1EECC00AA859B /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,7 +549,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/OAuth2Client.dst;
@@ -574,7 +571,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/OAuth2Client.dst;
 				GCC_MODEL_TUNING = G5;
@@ -593,7 +589,6 @@
 		1DEB922308733DC00010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -607,7 +602,6 @@
 		1DEB922408733DC00010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
@@ -621,7 +615,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -651,7 +644,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;

--- a/OAuth2Client.xcodeproj/project.pbxproj
+++ b/OAuth2Client.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94B6CE8119C1EECC00AA859B /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OAuth2Client.xcodeproj/project.pbxproj
+++ b/OAuth2Client.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		942FFD7E12315EFF00E6C65E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E5AC92122C097B00C7021A /* Security.framework */; };
 		945A500D123F7BAE00A6F2EB /* NXOAuth2ClientDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 824D5A6D123F68A8001177D5 /* NXOAuth2ClientDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94B6CE7219C1D3E400AA859B /* NXOAuth2PostBodyStreamSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 94B6CE7119C1D3E400AA859B /* NXOAuth2PostBodyStreamSpec.m */; };
+		94B6CE8119C1EECC00AA859B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94B6CE8019C1EECC00AA859B /* Info.plist */; };
 		94CCDD2219C1F29E00F9F148 /* libOAuth2Client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2AAC07E0554694100DB518D /* libOAuth2Client.a */; };
 		94E5AC93122C097B00C7021A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E5AC92122C097B00C7021A /* Security.framework */; };
 		99D8A7F913852C6E00E3073C /* NSData+NXOAuth2.h in Headers */ = {isa = PBXBuildFile; fileRef = 99D8A7F713852C6E00E3073C /* NSData+NXOAuth2.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -238,7 +238,7 @@
     result = (__bridge_transfer NSDictionary *)cfResult;
     
     if (status != noErr) {
-        NSAssert1(status == errSecItemNotFound, @"unexpected error while fetching token from keychain: %d", (int)status);
+        NSAssert1(status == errSecItemNotFound, @"unexpected error while fetching token from keychain: %@", (int)status);
         return nil;
     }
     
@@ -257,7 +257,7 @@
                            nil];
     [self removeFromDefaultKeychainWithServiceProviderName:provider];
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
-    NSAssert1(err == noErr, @"error while adding token to keychain: %d", (int)err);
+    NSAssert1(err == noErr, @"error while adding token to keychain: %@", (int)err);
 }
 
 - (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
@@ -268,7 +268,7 @@
                            serviceName, kSecAttrService,
                            nil];
     OSStatus __attribute__((unused)) err = SecItemDelete((__bridge CFDictionaryRef)query);
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %d", (int)err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %@", @(err));
 }
 
 #else
@@ -287,7 +287,7 @@
                                                   NULL,
                                                   &item);
     if (err != noErr) {
-        NSAssert1(err == errSecItemNotFound, @"unexpected error while fetching token from keychain: %d", err);
+        NSAssert1(err == errSecItemNotFound, @"unexpected error while fetching token from keychain: %@", @(err));
         return nil;
     }
     
@@ -314,7 +314,7 @@
         SecKeychainItemFreeContent(&list, password);
     } else {
         // TODO find out why this always works in i386 and always fails on ppc
-        NSLog(@"Error from SecKeychainItemCopyContent: %d", err);
+        NSLog(@"Error from SecKeychainItemCopyContent: %@", @(err));
         return nil;
     }
     CFRelease(item);
@@ -336,7 +336,7 @@
                                                                         [data bytes],
                                                                         NULL);
     
-    NSAssert1(err == noErr, @"error while adding token to keychain: %d", err);
+    NSAssert1(err == noErr, @"error while adding token to keychain: %@", @(err));
 }
 
 - (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
@@ -351,14 +351,14 @@
                                                   NULL,
                                                   NULL,
                                                   &item);
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %d", err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %@", @(err));
     if (err == noErr) {
         err = SecKeychainItemDelete(item);
     }
     if (item) {
         CFRelease(item);
     }
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %d", err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %@", @(err));
 }
 
 #endif

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -238,7 +238,7 @@
     result = (__bridge_transfer NSDictionary *)cfResult;
     
     if (status != noErr) {
-        NSAssert1(status == errSecItemNotFound, @"unexpected error while fetching token from keychain: %@", (int)status);
+        NSAssert1(status == errSecItemNotFound, @"unexpected error while fetching token from keychain: %@", @(status));
         return nil;
     }
     
@@ -257,7 +257,7 @@
                            nil];
     [self removeFromDefaultKeychainWithServiceProviderName:provider];
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
-    NSAssert1(err == noErr, @"error while adding token to keychain: %@", (int)err);
+    NSAssert1(err == noErr, @"error while adding token to keychain: %@", @(err));
 }
 
 - (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -643,7 +643,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                            serviceName, kSecAttrService,
                            nil];
     OSStatus __attribute__((unused)) err = SecItemDelete((__bridge CFDictionaryRef)query);
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting token from keychain: %zd", err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting token from keychain: %zd", @(err));
 
 }
 
@@ -663,7 +663,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                   NULL,
                                                   &item);
     if (err != noErr) {
-        NSAssert1(err == errSecItemNotFound, @"Unexpected error while fetching accounts from keychain: %d", err);
+        NSAssert1(err == errSecItemNotFound, @"Unexpected error while fetching accounts from keychain: %@", @(err));
         return nil;
     }
 
@@ -690,7 +690,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
         SecKeychainItemFreeContent(&list, password);
     } else {
         // TODO find out why this always works in i386 and always fails on ppc
-        NSLog(@"Error from SecKeychainItemCopyContent: %d", err);
+        NSLog(@"Error from SecKeychainItemCopyContent: %@", @(err));
         return nil;
     }
     CFRelease(item);
@@ -714,7 +714,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                                         [data bytes],
                                                                         NULL);
 
-    NSAssert1(err == noErr, @"Error while storing accounts in keychain: %d", err);
+    NSAssert1(err == noErr, @"Error while storing accounts in keychain: %@", @(err));
 }
 
 + (void)removeFromDefaultKeychain;
@@ -730,14 +730,14 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                   NULL,
                                                   NULL,
                                                   &item);
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting accounts from keychain: %d", err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting accounts from keychain: %@", @(err));
     if (err == noErr) {
         err = SecKeychainItemDelete(item);
     }
     if (item) {
         CFRelease(item);
     }
-    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting accounts from keychain: %d", err);
+    NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting accounts from keychain: %@", @(err));
 }
 
 #endif

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -237,7 +237,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             NSInputStream *postBodyStream = [[NXOAuth2PostBodyStream alloc] initWithParameters:parameters];
             
             contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@",[(NXOAuth2PostBodyStream *)postBodyStream boundary]];
-            NSString *contentLength = [NSString stringWithFormat:@"%lld", [(NXOAuth2PostBodyStream *)postBodyStream length]];
+            NSString *contentLength = [@([(NXOAuth2PostBodyStream *)postBodyStream length]) stringValue];
             [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
             [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
             
@@ -474,7 +474,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             }
         }
         
-        NSString *localizedError = [NSString stringWithFormat:NSLocalizedString(@"HTTP Error: %d", @"NXOAuth2HTTPErrorDomain description"), self.statusCode];
+        NSString *localizedError = [NSString stringWithFormat:NSLocalizedString(@"HTTP Error: %@", @"NXOAuth2HTTPErrorDomain description"), self.statusCode];
         NSDictionary *errorUserInfo = [NSDictionary dictionaryWithObject:localizedError forKey:NSLocalizedDescriptionKey];
         NSError *error = [NSError errorWithDomain:NXOAuth2HTTPErrorDomain
                                              code:self.statusCode

--- a/Sources/OAuth2Client/NXOAuth2PostBodyStream.m
+++ b/Sources/OAuth2Client/NXOAuth2PostBodyStream.m
@@ -30,8 +30,7 @@
 {
     self = [self init];
     if (self) {
-        srandom(time(NULL));
-        boundary = [[NSString alloc] initWithFormat:@"------------nx-oauth2%d", rand()];
+        boundary = [[NSString alloc] initWithFormat:@"------------nx-oauth2%@", @(arc4random())];
         numBytesTotal = 0;
         streamIndex = 0;
         
@@ -88,7 +87,7 @@
             NSData *delimiterData = [delimiter dataUsingEncoding:NSUTF8StringEncoding];
             NSData *contentHeaderData = [[part contentHeaders] dataUsingEncoding:NSUTF8StringEncoding];
             
-            int dataLength = delimiterData.length + contentHeaderData.length;
+            NSUInteger dataLength = delimiterData.length + contentHeaderData.length;
             NSMutableData *headerData = [NSMutableData dataWithCapacity: dataLength];
             [headerData appendData:delimiterData];
             [headerData appendData:contentHeaderData];
@@ -146,7 +145,7 @@
     if (currentStream == nil)
         return 0;
     
-    int result = [currentStream read:buffer maxLength:len];
+    NSInteger result = [currentStream read:buffer maxLength:len];
     
     if (result == 0) {
         if (streamIndex < contentStreams.count - 1) {

--- a/Sources/OAuth2Client/NXOAuth2Request.m
+++ b/Sources/OAuth2Client/NXOAuth2Request.m
@@ -163,7 +163,7 @@
         NSInputStream *postBodyStream = [[NXOAuth2PostBodyStream alloc] initWithParameters:parameters];
         
         NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", [(NXOAuth2PostBodyStream *)postBodyStream boundary]];
-        NSString *contentLength = [NSString stringWithFormat:@"%llu", [(NXOAuth2PostBodyStream *)postBodyStream length]];
+        NSString *contentLength = [@([(NXOAuth2PostBodyStream *)postBodyStream length]) stringValue];
         [aRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
         [aRequest setValue:contentLength forHTTPHeaderField:@"Content-Length"];
         


### PR DESCRIPTION
- I updated the project settings to remove a warning in Xcode 6.
- I used `NSInteger` or `NSUInteger` where required to avoid conversion with precision loss (warnings)
- I replaced several integer format keys (mainly in asserts) with object format keys so that no warning shows up in future SDK releases
