### PR TITLE
Added support for keychain access group under iOS

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2AccessToken.h
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.h
@@ -66,16 +66,14 @@
 
 #pragma mark Keychain Support
 
-+ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
-+ (instancetype)tokenFromKeychainWithServiceProviderName:(NSString *)provider
+//TODO: Support alternate KeyChain Locations
++ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider
                                          withAccessGroup:(NSString *)accessGroup;
 
-- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
-- (void)storeInKeychainWithServiceProviderName:(NSString *)provider
+- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider
                                withAccessGroup:(NSString *)accessGroup;
 
-- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
-- (void)removeFromKeychainWithServiceProviderName:(NSString *)provider
+- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider
                                   withAccessGroup:(NSString *)accessGroup;
 
 @end

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.h
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.h
@@ -66,10 +66,16 @@
 
 #pragma mark Keychain Support
 
-//TODO: Support alternate KeyChain Locations
++ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
++ (instancetype)tokenFromKeychainWithServiceProviderName:(NSString *)provider
+                                         withAccessGroup:(NSString *)accessGroup;
 
-+ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
-- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider;
-- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
+- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
+- (void)storeInKeychainWithServiceProviderName:(NSString *)provider
+                               withAccessGroup:(NSString *)accessGroup;
+
+- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider __attribute__ ((deprecated));
+- (void)removeFromKeychainWithServiceProviderName:(NSString *)provider
+                                  withAccessGroup:(NSString *)accessGroup;
 
 @end

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -239,9 +239,11 @@
                                   kCFBooleanTrue, kSecReturnAttributes,
                                   nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (accessGroup != nil) {
         [query setObject:accessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     CFTypeRef cfResult = nil;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &cfResult);
@@ -271,9 +273,11 @@
                                   data, kSecAttrGeneric,
                                   nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (accessGroup != nil) {
         [query setObject:accessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     [self removeFromKeychainWithServiceProviderName:provider withAccessGroup:accessGroup];
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
@@ -293,9 +297,11 @@
                            serviceName, kSecAttrService,
                            nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (accessGroup != nil) {
         [query setObject:accessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     OSStatus __attribute__((unused)) err = SecItemDelete((__bridge CFDictionaryRef)query);
     NSAssert1((err == noErr || err == errSecItemNotFound), @"error while deleting token from keychain: %d", (int)err);

--- a/Sources/OAuth2Client/NXOAuth2AccessToken.m
+++ b/Sources/OAuth2Client/NXOAuth2AccessToken.m
@@ -224,12 +224,7 @@
 
 #if TARGET_OS_IPHONE
 
-+ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
-{
-    return [NXOAuth2AccessToken tokenFromKeychainWithServiceProviderName:provider withAccessGroup:nil];
-}
-
-+ (instancetype)tokenFromKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup
++ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     NSDictionary *result = nil;
@@ -257,12 +252,7 @@
     return [NSKeyedUnarchiver unarchiveObjectWithData:[result objectForKey:(__bridge NSString *)kSecAttrGeneric]];
 }
 
-- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider;
-{
-    [self storeInKeychainWithServiceProviderName:provider withAccessGroup:nil];
-}
-
-- (void)storeInKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup
+- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self];
@@ -279,17 +269,12 @@
     }
 #endif
     
-    [self removeFromKeychainWithServiceProviderName:provider withAccessGroup:accessGroup];
+    [self removeFromDefaultKeychainWithServiceProviderName:provider withAccessGroup:accessGroup];
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
     NSAssert1(err == noErr, @"error while adding token to keychain: %d", (int)err);
 }
 
-- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
-{
-    [self removeFromKeychainWithServiceProviderName:provider withAccessGroup:nil];
-}
-
-- (void)removeFromKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup
+- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
@@ -309,7 +294,7 @@
 
 #else
 
-+ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
++ (instancetype)tokenFromDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     
@@ -357,9 +342,9 @@
     return [NSKeyedUnarchiver unarchiveObjectWithData:result];
 }
 
-- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider;
+- (void)storeInDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
-    [self removeFromDefaultKeychainWithServiceProviderName:provider];
+    [self removeFromDefaultKeychainWithServiceProviderName:provider withAccessGroup:accessGroup];
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self];
     
@@ -375,7 +360,7 @@
     NSAssert1(err == noErr, @"error while adding token to keychain: %d", err);
 }
 
-- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider;
+- (void)removeFromDefaultKeychainWithServiceProviderName:(NSString *)provider withAccessGroup:(NSString *)accessGroup;
 {
     NSString *serviceName = [[self class] serviceNameWithProvider:provider];
     SecKeychainItemRef item = nil;

--- a/Sources/OAuth2Client/NXOAuth2Account.m
+++ b/Sources/OAuth2Client/NXOAuth2Account.m
@@ -90,7 +90,8 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
             NSURL *authorizeURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAuthorizeURL];
             NSURL *tokenURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenURL];
             NSString *tokenType = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenType];
-            NSString *keychainGroup = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenType];
+            NSString *keychainGroup = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationKeyChainGroup];
+            NSString *keychainAccessGroup = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup];
             NSDictionary *additionalQueryParams = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters];
             NSDictionary *customHeaderFields = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationCustomHeaderFields];
 
@@ -101,6 +102,7 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
                                                        accessToken:self.accessToken
                                                          tokenType:tokenType
                                                      keyChainGroup:keychainGroup
+                                               keyChainAccessGroup:keychainAccessGroup
                                                         persistent:NO
                                                           delegate:self];
             if (additionalQueryParams) {

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.h
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.h
@@ -35,6 +35,8 @@ extern NSString * const kNXOAuth2AccountStoreConfigurationRedirectURL;
 extern NSString * const kNXOAuth2AccountStoreConfigurationScope;
 extern NSString * const kNXOAuth2AccountStoreConfigurationTokenType;
 extern NSString * const kNXOAuth2AccountStoreConfigurationTokenRequestHTTPMethod;
+extern NSString * const kNXOAuth2AccountStoreConfigurationKeyChainGroup;
+extern NSString * const kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup;
 
 /* 
  * Requires a NSDictionary as a value.
@@ -79,6 +81,8 @@ typedef void(^NXOAuth2PreparedAuthorizationURLHandler)(NSURL *preparedURL);
 
 #pragma mark Accessors
 
+@property(nonatomic, strong) NSString *keychainAccessGroup;
+@property(nonatomic, strong) NSString *keychainServiceName;
 @property(nonatomic, strong, readonly) NSArray *accounts;
 - (NSArray *)accountsWithAccountType:(NSString *)accountType;
 - (NXOAuth2Account *)accountWithIdentifier:(NSString *)identifier;

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -603,7 +603,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     @synchronized (self.accountsDict) {
         // The user data of an account has been changed.
-        // Save all accounts in the keychain.
+        // Save all accounts in the default keychain.
         [self storeAccountsInDefaultKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
     }
 }
@@ -612,7 +612,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     @synchronized (self.accountsDict) {
         // An access token of an account has been changed.
-        // Save all accounts in the keychain.
+        // Save all accounts in the default keychain.
         [self storeAccountsInDefaultKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
     }
 }

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -648,9 +648,11 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                   kCFBooleanTrue, kSecReturnAttributes,
                                   nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (keyChainAccessGroup) {
         [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     CFTypeRef cfResult = nil;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &cfResult);
@@ -678,9 +680,11 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                   data, kSecAttrGeneric,
                                   nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (keyChainAccessGroup) {
         [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
     NSAssert1(err == noErr, @"Error while adding token to keychain: %zd", err);
@@ -694,9 +698,11 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                   serviceName, kSecAttrService,
                                   nil];
     
+#ifndef TARGET_IPHONE_SIMULATOR
     if (keyChainAccessGroup) {
         [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
     }
+#endif
     
     OSStatus __attribute__((unused)) err = SecItemDelete((__bridge CFDictionaryRef)query);
     NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting token from keychain: %zd", err);

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -44,6 +44,7 @@ NSString * const kNXOAuth2AccountStoreConfigurationScope = @"kNXOAuth2AccountSto
 NSString * const kNXOAuth2AccountStoreConfigurationTokenType = @"kNXOAuth2AccountStoreConfigurationTokenType";
 NSString * const kNXOAuth2AccountStoreConfigurationTokenRequestHTTPMethod = @"kNXOAuth2AccountStoreConfigurationTokenRequestHTTPMethod";
 NSString * const kNXOAuth2AccountStoreConfigurationKeyChainGroup = @"kNXOAuth2AccountStoreConfigurationKeyChainGroup";
+NSString * const kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup = @"kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup";
 NSString * const kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters = @"kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters";
 NSString * const kNXOAuth2AccountStoreConfigurationCustomHeaderFields = @"kNXOAuth2AccountStoreConfigurationCustomHeaderFields";
 
@@ -75,10 +76,10 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 
 #pragma mark Keychain Support
 
-+ (NSString *)keychainServiceName;
-+ (NSDictionary *)accountsFromDefaultKeychain;
-+ (void)storeAccountsInDefaultKeychain:(NSDictionary *)accounts;
-+ (void)removeFromDefaultKeychain;
+- (NSString *)accountsKeychainServiceName;
+- (NSDictionary *)accountsFromtKeychainWithAccessGroup:(NSString *)keyChainAccessGroup;
+- (void)storeAccountsInKeychain:(NSDictionary *)accounts withAccessGroup:(NSString*)keyChainAccessGroup;
+- (void)removeFromKeychainWithAccessGroup:(NSString*)keyChainAccessGroup;
 
 @end
 
@@ -102,21 +103,20 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     self = [super init];
     if (self) {
         self.pendingOAuthClients = [NSMutableDictionary dictionary];
-        self.accountsDict = [NSMutableDictionary dictionaryWithDictionary:[NXOAuth2AccountStore accountsFromDefaultKeychain]];
         self.configurations = [NSMutableDictionary dictionary];
         self.trustModeHandler = [NSMutableDictionary dictionary];
         self.trustedCertificatesHandler = [NSMutableDictionary dictionary];
-
+        
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(accountDidChangeUserData:)
                                                      name:NXOAuth2AccountDidChangeUserDataNotification
                                                    object:nil];
-
+        
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(accountDidChangeAccessToken:)
                                                      name:NXOAuth2AccountDidChangeAccessTokenNotification
                                                    object:nil];
-
+        
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(accountDidLoseAccessToken:)
                                                      name:NXOAuth2AccountDidLoseAccessTokenNotification
@@ -139,6 +139,16 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 @synthesize configurations;
 @synthesize trustModeHandler;
 @synthesize trustedCertificatesHandler;
+
+- (NSMutableDictionary *)accountsDict;
+{
+    if (accountsDict == nil) {
+        accountsDict = [NSMutableDictionary dictionaryWithDictionary:
+                        [self accountsFromtKeychainWithAccessGroup:self.keychainAccessGroup]];
+    }
+    
+    return accountsDict;
+}
 
 - (NSArray *)accounts;
 {
@@ -219,7 +229,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     if (account) {
         @synchronized (self.accountsDict) {
             [self.accountsDict removeObjectForKey:account.identifier];
-            [NXOAuth2AccountStore storeAccountsInDefaultKeychain:self.accountsDict];
+            [self storeAccountsInKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
         }
         [[NSNotificationCenter defaultCenter] postNotificationName:NXOAuth2AccountStoreAccountsDidChangeNotification object:self];
     }
@@ -234,13 +244,19 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
         redirectURL:(NSURL *)aRedirectURL
      forAccountType:(NSString *)anAccountType;
 {
-    [self setConfiguration:[NSDictionary dictionaryWithObjectsAndKeys:
-                            aClientID, kNXOAuth2AccountStoreConfigurationClientID,
-                            aSecret, kNXOAuth2AccountStoreConfigurationSecret,
-                            anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
-                            aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
-                            aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil]
-            forAccountType:anAccountType];
+    NSMutableDictionary* config = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                   aClientID, kNXOAuth2AccountStoreConfigurationClientID,
+                                   aSecret, kNXOAuth2AccountStoreConfigurationSecret,
+                                   anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
+                                   aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
+                                   aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil];
+    
+    if (self.keychainAccessGroup) {
+        [config setObject:self.keychainAccessGroup
+                   forKey:kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup];
+    }
+    
+    [self setConfiguration:config forAccountType:anAccountType];
 }
 
 - (void)setClientID:(NSString *)aClientID
@@ -254,15 +270,21 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     NSAssert(aKeyChainGroup, @"keyChainGroup must be non-nil");
     
-    [self setConfiguration:[NSDictionary dictionaryWithObjectsAndKeys:
-                            aClientID, kNXOAuth2AccountStoreConfigurationClientID,
-                            aSecret, kNXOAuth2AccountStoreConfigurationSecret,
-                            theScope, kNXOAuth2AccountStoreConfigurationScope,
-                            anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
-                            aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
-                            aKeyChainGroup, kNXOAuth2AccountStoreConfigurationKeyChainGroup,
-                            aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil]
-            forAccountType:anAccountType];
+    NSMutableDictionary* config = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                   aClientID, kNXOAuth2AccountStoreConfigurationClientID,
+                                   aSecret, kNXOAuth2AccountStoreConfigurationSecret,
+                                   theScope, kNXOAuth2AccountStoreConfigurationScope,
+                                   anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
+                                   aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
+                                   aKeyChainGroup, kNXOAuth2AccountStoreConfigurationKeyChainGroup,
+                                   aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil];
+    
+    if (self.keychainAccessGroup) {
+        [config setObject:self.keychainAccessGroup
+                   forKey:kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup];
+    }
+    
+    [self setConfiguration:config forAccountType:anAccountType];
 }
 
 - (void)setClientID:(NSString *)aClientID
@@ -278,16 +300,22 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     NSAssert(aKeyChainGroup, @"keyChainGroup must be non-nil");
     NSAssert(aTokenType, @"tokenType must be non-nil");
     
-    [self setConfiguration:[NSDictionary dictionaryWithObjectsAndKeys:
-                            aClientID, kNXOAuth2AccountStoreConfigurationClientID,
-                            aSecret, kNXOAuth2AccountStoreConfigurationSecret,
-                            theScope, kNXOAuth2AccountStoreConfigurationScope,
-                            anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
-                            aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
-                            aTokenType, kNXOAuth2AccountStoreConfigurationTokenType,
-                            aKeyChainGroup, kNXOAuth2AccountStoreConfigurationKeyChainGroup,
-                            aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil]
-            forAccountType:anAccountType];
+    NSMutableDictionary* config = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                   aClientID, kNXOAuth2AccountStoreConfigurationClientID,
+                                   aSecret, kNXOAuth2AccountStoreConfigurationSecret,
+                                   theScope, kNXOAuth2AccountStoreConfigurationScope,
+                                   anAuthorizationURL, kNXOAuth2AccountStoreConfigurationAuthorizeURL,
+                                   aTokenURL, kNXOAuth2AccountStoreConfigurationTokenURL,
+                                   aTokenType, kNXOAuth2AccountStoreConfigurationTokenType,
+                                   aKeyChainGroup, kNXOAuth2AccountStoreConfigurationKeyChainGroup,
+                                   aRedirectURL, kNXOAuth2AccountStoreConfigurationRedirectURL, nil];
+    
+    if (self.keychainAccessGroup) {
+        [config setObject:self.keychainAccessGroup
+                   forKey:kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup];
+    }
+    
+    [self setConfiguration:config forAccountType:anAccountType];
 }
 
 - (void)setConfiguration:(NSDictionary *)configuration
@@ -409,6 +437,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
             NSString *tokenType = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenType];
             NSString *tokenRequestHTTPMethod = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationTokenRequestHTTPMethod];
             NSString *keychainGroup = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationKeyChainGroup];
+            NSString *keychainAccessGroup = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationKeyChainAccessGroup];
             NSDictionary *additionalAuthenticationParameters = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAdditionalAuthenticationParameters];
             NSDictionary *customHeaderFields = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationCustomHeaderFields];
 
@@ -419,6 +448,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
                                                   accessToken:nil
                                                     tokenType:tokenType
                                                 keyChainGroup:keychainGroup
+                                          keyChainAccessGroup:keychainAccessGroup
                                                    persistent:YES
                                                      delegate:self];
 
@@ -500,7 +530,7 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     @synchronized (self.accountsDict) {
         [self.accountsDict setValue:account forKey:account.identifier];
-        [NXOAuth2AccountStore storeAccountsInDefaultKeychain:self.accountsDict];
+        [self storeAccountsInKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
     }
 
     NSDictionary *userInfo = [NSDictionary dictionaryWithObject:account
@@ -571,8 +601,8 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     @synchronized (self.accountsDict) {
         // The user data of an account has been changed.
-        // Save all accounts in the default keychain.
-        [NXOAuth2AccountStore storeAccountsInDefaultKeychain:self.accountsDict];
+        // Save all accounts in the keychain.
+        [self storeAccountsInKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
     }
 }
 
@@ -580,8 +610,8 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 {
     @synchronized (self.accountsDict) {
         // An access token of an account has been changed.
-        // Save all accounts in the default keychain.
-        [NXOAuth2AccountStore storeAccountsInDefaultKeychain:self.accountsDict];
+        // Save all accounts in the keychain.
+        [self storeAccountsInKeychain:self.accountsDict withAccessGroup:self.keychainAccessGroup];
     }
 }
 
@@ -593,24 +623,35 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
 
 #pragma mark Keychain Support
 
-+ (NSString *)keychainServiceName;
+- (NSString *)accountsKeychainServiceName;
 {
-    NSString *appName = [[NSBundle mainBundle] bundleIdentifier];
-    return [NSString stringWithFormat:@"%@::NXOAuth2AccountStore", appName];
+    NSString *serviceName = self.keychainServiceName;
+    
+    if (!serviceName) {
+        NSString *appName = [[NSBundle mainBundle] bundleIdentifier];
+        serviceName = [NSString stringWithFormat:@"%@::NXOAuth2AccountStore", appName];
+    }
+    
+    return serviceName;
 }
 
 #if TARGET_OS_IPHONE
 
-+ (NSDictionary *)accountsFromDefaultKeychain;
+- (NSDictionary *)accountsFromtKeychainWithAccessGroup:(NSString *)keyChainAccessGroup
 {
-    NSString *serviceName = [self keychainServiceName];
+    NSString *serviceName = [self accountsKeychainServiceName];
 
     NSDictionary *result = nil;
-    NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
-                           (__bridge NSString *)kSecClassGenericPassword, kSecClass,
-                           serviceName, kSecAttrService,
-                           kCFBooleanTrue, kSecReturnAttributes,
-                           nil];
+    NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                  (__bridge NSString *)kSecClassGenericPassword, kSecClass,
+                                  serviceName, kSecAttrService,
+                                  kCFBooleanTrue, kSecReturnAttributes,
+                                  nil];
+    
+    if (keyChainAccessGroup) {
+        [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
+    }
+    
     CFTypeRef cfResult = nil;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &cfResult);
     result = (__bridge_transfer NSDictionary *)cfResult;
@@ -623,30 +664,40 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
     return [NSKeyedUnarchiver unarchiveObjectWithData:[result objectForKey:(__bridge NSString *)kSecAttrGeneric]];
 }
 
-+ (void)storeAccountsInDefaultKeychain:(NSDictionary *)accounts;
+- (void)storeAccountsInKeychain:(NSDictionary *)accounts withAccessGroup:(NSString *)keyChainAccessGroup
 {
-    [self removeFromDefaultKeychain];
+    [self removeFromKeychainWithAccessGroup:keyChainAccessGroup];
 
-    NSString *serviceName = [self keychainServiceName];
+    NSString *serviceName = [self accountsKeychainServiceName];
 
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:accounts];
-    NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
-                           (__bridge NSString *)kSecClassGenericPassword, kSecClass,
-                           serviceName, kSecAttrService,
-                           @"OAuth 2 Account Store", kSecAttrLabel,
-                           data, kSecAttrGeneric,
-                           nil];
+    NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                  (__bridge NSString *)kSecClassGenericPassword, kSecClass,
+                                  serviceName, kSecAttrService,
+                                  @"OAuth 2 Account Store", kSecAttrLabel,
+                                  data, kSecAttrGeneric,
+                                  nil];
+    
+    if (keyChainAccessGroup) {
+        [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
+    }
+    
     OSStatus __attribute__((unused)) err = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
     NSAssert1(err == noErr, @"Error while adding token to keychain: %zd", err);
 }
 
-+ (void)removeFromDefaultKeychain;
+- (void)removeFromKeychainWithAccessGroup:(NSString *)keyChainAccessGroup
 {
-    NSString *serviceName = [self keychainServiceName];
-    NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
-                           (__bridge NSString *)kSecClassGenericPassword, kSecClass,
-                           serviceName, kSecAttrService,
-                           nil];
+    NSString *serviceName = [self accountsKeychainServiceName];
+    NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                  (__bridge NSString *)kSecClassGenericPassword, kSecClass,
+                                  serviceName, kSecAttrService,
+                                  nil];
+    
+    if (keyChainAccessGroup) {
+        [query setObject:keyChainAccessGroup forKey:(__bridge NSString *)kSecAttrAccessGroup];
+    }
+    
     OSStatus __attribute__((unused)) err = SecItemDelete((__bridge CFDictionaryRef)query);
     NSAssert1((err == noErr || err == errSecItemNotFound), @"Error while deleting token from keychain: %zd", err);
 

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -43,6 +43,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
     NSString    *userAgent;
     NSString    *assertion;
     NSString    *keyChainGroup;
+    NSString    *keyChainAccessGroup;
     
     // server information
     NSURL        *authorizeURL;
@@ -97,6 +98,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
                         tokenURL:(NSURL *)tokenURL
                      accessToken:(NXOAuth2AccessToken *)accessToken
                    keyChainGroup:(NSString *)keyChainGroup
+             keyChainAccessGroup:(NSString *)keyChainAccessGroup
                       persistent:(BOOL)shouldPersist
                         delegate:(NSObject<NXOAuth2ClientDelegate> *)delegate;
 
@@ -107,6 +109,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
                      accessToken:(NXOAuth2AccessToken *)accessToken
                        tokenType:(NSString *)tokenType
                    keyChainGroup:(NSString *)keyChainGroup
+             keyChainAccessGroup:(NSString *)keyChainAccessGroup
                       persistent:(BOOL)shouldPersist
                         delegate:(NSObject<NXOAuth2ClientDelegate> *)delegate;
 

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -151,12 +151,12 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (persistent == shouldPersist) return;
     
     if (shouldPersist && accessToken) {
-        [self.accessToken storeInKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+        [self.accessToken storeInDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
                                                  withAccessGroup:keyChainAccessGroup];
     }
     
     if (persistent && !shouldPersist) {
-        [accessToken removeFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+        [accessToken removeFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
                                                withAccessGroup:keyChainAccessGroup];
     }
 
@@ -170,7 +170,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (accessToken) return accessToken;
     
     if (persistent) {
-        accessToken = [NXOAuth2AccessToken tokenFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+        accessToken = [NXOAuth2AccessToken tokenFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
                                                                     withAccessGroup:keyChainAccessGroup];
         if (accessToken) {
             if ([delegate respondsToSelector:@selector(oauthClientDidGetAccessToken:)]) {
@@ -189,7 +189,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     BOOL authorisationStatusChanged = ((accessToken == nil)    || (value == nil)); //They can't both be nil, see one line above. So they have to have changed from or to nil.
     
     if (!value) {
-        [self.accessToken removeFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+        [self.accessToken removeFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
                                                     withAccessGroup:keyChainAccessGroup];
     }
     
@@ -198,7 +198,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     [self didChangeValueForKey:@"accessToken"];
     
     if (persistent) {
-        [accessToken storeInKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+        [accessToken storeInDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
                                             withAccessGroup:keyChainAccessGroup];
     }
     

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -49,6 +49,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                          tokenURL:aTokenURL
                       accessToken:nil
                     keyChainGroup:nil
+              keyChainAccessGroup:nil
                        persistent:YES
                          delegate:aDelegate];
 }
@@ -59,6 +60,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                         tokenURL:(NSURL *)aTokenURL
                      accessToken:(NXOAuth2AccessToken *)anAccessToken
                    keyChainGroup:(NSString *)aKeyChainGroup
+             keyChainAccessGroup:(NSString *)aKeyChainAccessGroup
                       persistent:(BOOL)shouldPersist
                         delegate:(NSObject<NXOAuth2ClientDelegate> *)aDelegate;
 {
@@ -69,6 +71,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                       accessToken:anAccessToken
                         tokenType:nil
                     keyChainGroup:aKeyChainGroup
+              keyChainAccessGroup:aKeyChainAccessGroup
                        persistent:shouldPersist
                          delegate:aDelegate];
 }
@@ -80,6 +83,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
                      accessToken:(NXOAuth2AccessToken *)anAccessToken
                        tokenType:(NSString *)aTokenType
                    keyChainGroup:(NSString *)aKeyChainGroup
+             keyChainAccessGroup:(NSString *)aKeyChainAccessGroup
                       persistent:(BOOL)shouldPersist
                         delegate:(NSObject<NXOAuth2ClientDelegate> *)aDelegate;
 {
@@ -98,6 +102,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
         self.tokenRequestHTTPMethod = @"POST";
         self.acceptType = @"application/json";
         keyChainGroup = aKeyChainGroup;
+        keyChainAccessGroup = aKeyChainAccessGroup;
         
         self.persistent = shouldPersist;
         self.delegate = aDelegate;
@@ -146,11 +151,13 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (persistent == shouldPersist) return;
     
     if (shouldPersist && accessToken) {
-        [self.accessToken storeInDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]];
+        [self.accessToken storeInKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+                                                 withAccessGroup:keyChainAccessGroup];
     }
     
     if (persistent && !shouldPersist) {
-        [accessToken removeFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]];
+        [accessToken removeFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+                                               withAccessGroup:keyChainAccessGroup];
     }
 
     [self willChangeValueForKey:@"persistent"];
@@ -163,7 +170,8 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     if (accessToken) return accessToken;
     
     if (persistent) {
-        accessToken = [NXOAuth2AccessToken tokenFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]];
+        accessToken = [NXOAuth2AccessToken tokenFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+                                                                    withAccessGroup:keyChainAccessGroup];
         if (accessToken) {
             if ([delegate respondsToSelector:@selector(oauthClientDidGetAccessToken:)]) {
                 [delegate oauthClientDidGetAccessToken:self];
@@ -181,7 +189,8 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     BOOL authorisationStatusChanged = ((accessToken == nil)    || (value == nil)); //They can't both be nil, see one line above. So they have to have changed from or to nil.
     
     if (!value) {
-        [self.accessToken removeFromDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]];
+        [self.accessToken removeFromKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+                                                    withAccessGroup:keyChainAccessGroup];
     }
     
     [self willChangeValueForKey:@"accessToken"];
@@ -189,7 +198,8 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
     [self didChangeValueForKey:@"accessToken"];
     
     if (persistent) {
-        [accessToken storeInDefaultKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]];
+        [accessToken storeInKeychainWithServiceProviderName:keyChainGroup ? keyChainGroup : [tokenURL host]
+                                            withAccessGroup:keyChainAccessGroup];
     }
     
     if (authorisationStatusChanged) {


### PR DESCRIPTION
I added support to specify a keychain access group to the account store.  This allows the accounts to be stored in the default keychain with a specified access group.  I also added support to specify the service name for the accounts item in account store.  With both these modifications, it allows an application extension to access the accounts from the default keychain that was stored by the application.

I also made the account store propagate the keychain access group to the oauth2client so the access token will be saved with the same keychain access group.

Keep in mind only the iOS keychain methods actually set the keychain access group.  The OS X version of the methods have been updated to take the keychain access group parameter, but don't do anything with it.  This is because the OS X versions are using an older keychain API that don't allow you to specify a keychain access group.  I'm not for sure why they are using the older API, as I believe the API used in the iOS methods is supported on OS X.

Also something else to note, there was a parameter added to the oauth2client and as a configuration for the account store called keychaingroup a while back.  This is actually the service name to use for the access token when stored by the oauth2client.  The name is confusing, but I chose to leave it be for now.
