### PR TITLE
Fix compilation error for NXOAuth2AccountStore accessToken property

### DIFF
--- a/NXOAuth2Account+Private.h
+++ b/NXOAuth2Account+Private.h
@@ -21,4 +21,6 @@
 - (instancetype)initAccountWithAccessToken:(NXOAuth2AccessToken *)accessToken
                                accountType:(NSString *)accountType;
 
+@property (nonatomic, strong) NXOAuth2AccessToken *accessToken;
+
 @end

--- a/Sources/OAuth2Client/NXOAuth2Account.m
+++ b/Sources/OAuth2Client/NXOAuth2Account.m
@@ -33,6 +33,8 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
 #pragma mark -
 
 @interface NXOAuth2Account () <NXOAuth2ClientDelegate, NXOAuth2TrustDelegate>
+
+@property (nonatomic, strong) NXOAuth2AccessToken *accessToken;
 @end
 
 #pragma mark -
@@ -84,7 +86,7 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
     @synchronized (oauthClient) {
         if (oauthClient == nil) {
             NSDictionary *configuration = [[NXOAuth2AccountStore sharedStore] configurationForAccountType:self.accountType];
-            
+
             NSString *clientID = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationClientID];
             NSString *clientSecret = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationSecret];
             NSURL *authorizeURL = [configuration objectForKey:kNXOAuth2AccountStoreConfigurationAuthorizeURL];
@@ -106,11 +108,11 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
             if (additionalQueryParams) {
                 oauthClient.additionalAuthenticationParameters = additionalQueryParams;
             }
-            
+
             if (customHeaderFields) {
                 oauthClient.customHeaderFields = customHeaderFields;
             }
-            
+
         }
     }
     return oauthClient;


### PR DESCRIPTION
![nxoauth2accountstore_m](https://cloud.githubusercontent.com/assets/12001/7324594/54dcedec-ea7d-11e4-816d-cbde3c6ad6e6.png)

cherry-pick d78dd61b90138207ffd962ae98d8fc54f471ba05 which fixes the compilation error introduced by #171 due to incomplete cherry-pick.

Sorry for the first pull request missing this file!  I didn't smoketest the code enough before the first pull request and thought that there was a testsuite to catch compilation issues.
