### PR TITLE
Automatically Request Access for Connections

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -76,6 +76,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
 @property (nonatomic, strong) NXOAuth2AccessToken    *accessToken;
 @property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ClientDelegate>*    delegate;
 
+@property (nonatomic, readonly) NXOAuth2Connection *authConnection;
 
 /*!
  * If set to NO, the access token is not stored any keychain, will be removed if it was.

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -143,6 +143,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
 #pragma mark Public
 
 - (void)requestAccess;
+- (void)requestAccessAndRetryConnection:(NXOAuth2Connection *)retryConnection;
 
 - (void)refreshAccessToken;
 - (void)refreshAccessTokenAndRetryConnection:(NXOAuth2Connection *)retryConnection;

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -233,7 +233,18 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 
 - (void)requestAccess;
 {
+    [self requestAccessAndRetryConnection:nil];
+}
+
+- (void)requestAccessAndRetryConnection:(NXOAuth2Connection *)retryConnection
+{
     if (!self.accessToken) {
+        
+        if (retryConnection) {
+            if (!waitingConnections) waitingConnections = [[NSMutableArray alloc] init];
+            [waitingConnections addObject:retryConnection];
+        }
+        
         [delegate oauthClientNeedsAuthentication:self];
     }
 }

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -122,6 +122,7 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 @synthesize desiredScope, userAgent;
 @synthesize delegate, persistent, accessToken, authenticating;
 @synthesize additionalAuthenticationParameters;
+@synthesize authConnection = authConnection;
 
 - (void)setAdditionalAuthenticationParameters:(NSDictionary *)value;
 {

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -416,10 +416,10 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
         }
     }
     
-    if (authenticateHeader && client.accessToken.refreshToken != nil && [authenticateHeader rangeOfString:@"expired_token"].location != NSNotFound) {
+    if (client.authConnection != self && authenticateHeader && client.accessToken.refreshToken != nil && [authenticateHeader rangeOfString:@"expired_token"].location != NSNotFound) {
         [self cancel];
         [client refreshAccessTokenAndRetryConnection:self];
-    } else if (authenticateHeader && client) {
+    } else if (client.authConnection != self && authenticateHeader && client) {
         [self cancel];
         [client requestAccessAndRetryConnection:self];
     } else {

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -415,12 +415,13 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             }
         }
     }
-    if (self.statusCode == 401
-        && client.accessToken.refreshToken != nil
-        && authenticateHeader
-        && [authenticateHeader rangeOfString:@"expired_token"].location != NSNotFound) {
+    
+    if (authenticateHeader && client.accessToken.refreshToken != nil && [authenticateHeader rangeOfString:@"expired_token"].location != NSNotFound) {
         [self cancel];
         [client refreshAccessTokenAndRetryConnection:self];
+    } else if (authenticateHeader && client) {
+        [self cancel];
+        [client requestAccessAndRetryConnection:self];
     } else {
         if ([delegate respondsToSelector:@selector(oauthConnection:didReceiveData:)]) {
             [delegate oauthConnection:self didReceiveData:data];    // inform the delegate that we start with empty data


### PR DESCRIPTION
Add automatic request of access, if a connection made with the auth client needs authentication.

With this, a connection can be created and directly used. If the server responses with an header indicating, that authorization is needed, the method `-[NXOAuth2Client requestAccessAndRetryConnection:]` is called. From there the normal flow for authentication starts. After a successful authentication, the original connection is retried.
