### PR TITLE
Add error parameter for handling redirect URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ Once you have configured your client you are ready to request access to one of t
  [[NXOAuth2AccountStore sharedStore] requestAccessToAccountWithType:@"myFancyService"];
  </pre>
   
- If you are using an external browser, your application needs to handle the URL you have registered as an redirect URL for the account type. The service will redirect to that URL after the authentication process.
+ If you are using an external browser, your application needs to handle the URL you have registered as an redirect URL for the account type (e.g. a custom URL scheme like `myfancyscheme://oauth`). The service will redirect to that URL after the authentication process.
+ 
+ In `-[AppDelegate application: openURL: sourceApplication: annotation:]` pass the redirect URL to
+ <pre>
+     [[NXOAuth2AccountStore sharedStore] handleRedirectURL: url];
+ </pre>
 
 - Provide an Authorization URL Handler
  <pre>
@@ -128,7 +133,7 @@ Once you have configured your client you are ready to request access to one of t
  [_webView loadRequest:[NSURLRequest requestWithURL:preparedURL]];
  </pre>
  
-  2) In the `webViewDidFinishLoad:` delegate method, you will need to parse the URL for your callback URL.  If there is a match, pass that URL to `handleRedirectURL:`
+  2) In the `webViewDidFinishLoad:` delegate method, you will need to parse the URL for your callback URL.  If there is a match, pass that URL to `-[NXOAuth2AccountStore handleRedirectURL:]`
 
  <pre>
  if ([webView.request.URL.absoluteString rangeOfString:kOAuth2RedirectURL options:NSCaseInsensitiveSearch].location != NSNotFound) {
@@ -136,7 +141,7 @@ Once you have configured your client you are ready to request access to one of t
     }
 </pre>   
 
-This is a very basic example.  In the above, it is assumed that the `code` being returned from the OAuth2 provider is in the query parameter of the webView.request.URL (i.e. `http://myredirecturl.com?code=<verylongcodestring>`).  This is not always the case and you may have to look elsewhere for the code (e.g. in the page content, web page title).  You must prepare a URL in the format described above to pass to `handleRedirectURL:`.
+This is a very basic example.  In the above, it is assumed that the `code` being returned from the OAuth2 provider is in the query parameter of the webView.request.URL (i.e. `http://myredirecturl.com?code=<verylongcodestring>`).  This is not always the case and you may have to look elsewhere for the code (e.g. in the page content, web page title).  You must prepare a URL in the format described above to pass to `-[NXOAuth2AccountStore handleRedirectURL:]`.
 
 #### On Success
 

--- a/Sources/NSURL+NXOAuth2.h
+++ b/Sources/NSURL+NXOAuth2.h
@@ -26,4 +26,6 @@
 - (NSURL *)nxoauth2_URLWithoutQueryString;
 - (NSString *)nxoauth2_URLStringWithoutQueryString;
 
+- (NSError*) nxoauth2_redirectURLError;
+
 @end

--- a/Sources/NSURL+NXOAuth2.m
+++ b/Sources/NSURL+NXOAuth2.m
@@ -14,7 +14,7 @@
 #import "NSString+NXOAuth2.h"
 
 #import "NSURL+NXOAuth2.h"
-
+#import "NXOAuth2Constants.h"
 
 @implementation NSURL (NXOAuth2)
 
@@ -60,6 +60,53 @@
 {
     NSArray *parts = [[self absoluteString] componentsSeparatedByString:@"?"];
     return [parts objectAtIndex:0];
+}
+
+- (NSError*) nxoauth2_redirectURLError
+{
+    NSURL* redirectURL = self;
+    NSInteger errorCode = 0;
+    NSDictionary *userInfo = nil;
+    NSString *errorString = [redirectURL nxoauth2_valueForQueryParameterKey:@"error"];
+    if (errorString) {
+        NSString *localizedError = nil;
+        
+        if ([errorString caseInsensitiveCompare:@"invalid_request"] == NSOrderedSame) {
+            errorCode = NXOAuth2InvalidRequestErrorCode;
+            localizedError = NSLocalizedString(@"Invalid request to OAuth2 Server", @"NXOAuth2InvalidRequestErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"invalid_client"] == NSOrderedSame) {
+            errorCode = NXOAuth2InvalidClientErrorCode;
+            localizedError = NSLocalizedString(@"Invalid OAuth2 Client", @"NXOAuth2InvalidClientErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"unauthorized_client"] == NSOrderedSame) {
+            errorCode = NXOAuth2UnauthorizedClientErrorCode;
+            localizedError = NSLocalizedString(@"Unauthorized Client", @"NXOAuth2UnauthorizedClientErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"redirect_uri_mismatch"] == NSOrderedSame) {
+            errorCode = NXOAuth2RedirectURIMismatchErrorCode;
+            localizedError = NSLocalizedString(@"Redirect URI mismatch", @"NXOAuth2RedirectURIMismatchErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"access_denied"] == NSOrderedSame) {
+            errorCode = NXOAuth2AccessDeniedErrorCode;
+            localizedError = NSLocalizedString(@"Access denied", @"NXOAuth2AccessDeniedErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"unsupported_response_type"] == NSOrderedSame) {
+            errorCode = NXOAuth2UnsupportedResponseTypeErrorCode;
+            localizedError = NSLocalizedString(@"Unsupported response type", @"NXOAuth2UnsupportedResponseTypeErrorCode description");
+            
+        } else if ([errorString caseInsensitiveCompare:@"invalid_scope"] == NSOrderedSame) {
+            errorCode = NXOAuth2InvalidScopeErrorCode;
+            localizedError = NSLocalizedString(@"Invalid scope", @"NXOAuth2InvalidScopeErrorCode description");
+        }
+        
+        if (localizedError) {
+            userInfo = [NSDictionary dictionaryWithObject:localizedError forKey:NSLocalizedDescriptionKey];
+        }
+    }
+    return [NSError errorWithDomain:NXOAuth2ErrorDomain
+                               code:errorCode
+                           userInfo:userInfo];
 }
 
 @end

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.h
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.h
@@ -144,5 +144,6 @@ typedef void(^NXOAuth2PreparedAuthorizationURLHandler)(NSURL *preparedURL);
 #pragma mark Handle OAuth Redirects
 
 - (BOOL)handleRedirectURL:(NSURL *)URL;
+- (BOOL)handleRedirectURL:(NSURL *)aURL error: (NSError**) error;
 
 @end

--- a/Sources/OAuth2Client/NXOAuth2AccountStore.m
+++ b/Sources/OAuth2Client/NXOAuth2AccountStore.m
@@ -544,13 +544,15 @@ NSString * const kNXOAuth2AccountStoreAccountType = @"kNXOAuth2AccountStoreAccou
         }
     }
     
-    foundAccount.accessToken = client.accessToken;
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObject: foundAccount
-                                                         forKey: NXOAuth2AccountStoreNewAccountUserInfoKey];
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:NXOAuth2AccountStoreAccountsDidChangeNotification
-                                                        object:self
-                                                      userInfo:userInfo];
+    if (foundAccount) {
+        foundAccount.accessToken = client.accessToken;
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject: foundAccount
+                                                             forKey: NXOAuth2AccountStoreNewAccountUserInfoKey];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:NXOAuth2AccountStoreAccountsDidChangeNotification
+                                                            object:self
+                                                          userInfo:userInfo];
+    }
 }
 
 - (void)addAccount:(NXOAuth2Account *)account;

--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -115,6 +115,7 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
                         delegate:(NSObject<NXOAuth2ClientDelegate> *)delegate;
 
 - (BOOL)openRedirectURL:(NSURL *)URL;
+- (BOOL)openRedirectURL:(NSURL *)URL error: (NSError**) error;
 
 
 #pragma mark Authorisation Methods

--- a/Sources/OAuth2Client/NXOAuth2Client.m
+++ b/Sources/OAuth2Client/NXOAuth2Client.m
@@ -273,59 +273,26 @@ NSString * const NXOAuth2ClientConnectionContextTokenRefresh = @"tokenRefresh";
 // Web Server Flow only
 - (BOOL)openRedirectURL:(NSURL *)URL;
 {
+    return [self openRedirectURL:URL error:nil];
+}
+
+- (BOOL)openRedirectURL:(NSURL *)URL error: (NSError**) error;
+{
     NSString *accessGrant = [URL nxoauth2_valueForQueryParameterKey:@"code"];
     if (accessGrant) {
         [self requestTokenWithAuthGrant:accessGrant redirectURL:[URL nxoauth2_URLWithoutQueryString]];
         return YES;
     }
-    
-    NSString *errorString = [URL nxoauth2_valueForQueryParameterKey:@"error"];
-    if (errorString) {
-        NSInteger errorCode = 0;
-        NSString *localizedError = nil;
-        
-        if ([errorString caseInsensitiveCompare:@"invalid_request"] == NSOrderedSame) {
-            errorCode = NXOAuth2InvalidRequestErrorCode;
-            localizedError = NSLocalizedString(@"Invalid request to OAuth2 Server", @"NXOAuth2InvalidRequestErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"invalid_client"] == NSOrderedSame) {
-            errorCode = NXOAuth2InvalidClientErrorCode;
-            localizedError = NSLocalizedString(@"Invalid OAuth2 Client", @"NXOAuth2InvalidClientErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"unauthorized_client"] == NSOrderedSame) {
-            errorCode = NXOAuth2UnauthorizedClientErrorCode;
-            localizedError = NSLocalizedString(@"Unauthorized Client", @"NXOAuth2UnauthorizedClientErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"redirect_uri_mismatch"] == NSOrderedSame) {
-            errorCode = NXOAuth2RedirectURIMismatchErrorCode;
-            localizedError = NSLocalizedString(@"Redirect URI mismatch", @"NXOAuth2RedirectURIMismatchErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"access_denied"] == NSOrderedSame) {
-            errorCode = NXOAuth2AccessDeniedErrorCode;
-            localizedError = NSLocalizedString(@"Access denied", @"NXOAuth2AccessDeniedErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"unsupported_response_type"] == NSOrderedSame) {
-            errorCode = NXOAuth2UnsupportedResponseTypeErrorCode;
-            localizedError = NSLocalizedString(@"Unsupported response type", @"NXOAuth2UnsupportedResponseTypeErrorCode description");
-            
-        } else if ([errorString caseInsensitiveCompare:@"invalid_scope"] == NSOrderedSame) {
-            errorCode = NXOAuth2InvalidScopeErrorCode;
-            localizedError = NSLocalizedString(@"Invalid scope", @"NXOAuth2InvalidScopeErrorCode description");
+    else{
+        NSError* oauthError = [URL nxoauth2_redirectURLError];
+        if (oauthError && error) {
+            *error = oauthError;
         }
-        
-        if (errorCode != 0) {
-            NSDictionary *userInfo = nil;
-            if (localizedError) {
-                userInfo = [NSDictionary dictionaryWithObject:localizedError forKey:NSLocalizedDescriptionKey];
-            }
-            if ([delegate respondsToSelector:@selector(oauthClient:didFailToGetAccessTokenWithError:)]) {
-                [delegate oauthClient:self didFailToGetAccessTokenWithError:[NSError errorWithDomain:NXOAuth2ErrorDomain
-                                                                                                code:errorCode
-                                                                                            userInfo:userInfo]];
-            }
+        if ([delegate respondsToSelector:@selector(oauthClient:didFailToGetAccessTokenWithError:)]) {
+            [delegate oauthClient:self didFailToGetAccessTokenWithError: oauthError];
         }
+        return NO;
     }
-    return NO;
 }
 
 #pragma mark Request Token


### PR DESCRIPTION
`-[NXOAuth2AccountStore handleRedirectURL:]` returns a `BOOL` and a `NSError` is created further down in `-[NXOAuth2Client openRedirectURL:]` if the redirect URL contains an error. The way to get the error is to listen to a notification. 

It's more obvious how to get the error if a `(NSError**) error` parameter is passed in. This also conforms to the [pattern recommended by Apple](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html#//apple_ref/doc/uid/TP40001806-CH204-BAJIIGCC). Nothing is asynchronous, so a notification is not necessary. I left the notification in however.

When I checked out NXOAuth2 I didn't immediately understand what to do with the redirect URL, so I emphasized that in the `README`.
