### PR TITLE
fixed implicit conversion warnings

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2PostBodyStream.m
+++ b/Sources/OAuth2Client/NXOAuth2PostBodyStream.m
@@ -30,7 +30,11 @@
 {
     self = [self init];
     if (self) {
-        srandom(time(NULL));
+#if __DARWIN_UNIX03
+        srandom((unsigned) time(NULL));
+#else
+        srandom((unsigned long) time(NULL));
+#endif
         boundary = [[NSString alloc] initWithFormat:@"------------nx-oauth2%d", rand()];
         numBytesTotal = 0;
         streamIndex = 0;
@@ -88,7 +92,7 @@
             NSData *delimiterData = [delimiter dataUsingEncoding:NSUTF8StringEncoding];
             NSData *contentHeaderData = [[part contentHeaders] dataUsingEncoding:NSUTF8StringEncoding];
             
-            int dataLength = delimiterData.length + contentHeaderData.length;
+            NSUInteger dataLength = delimiterData.length + contentHeaderData.length;
             NSMutableData *headerData = [NSMutableData dataWithCapacity: dataLength];
             [headerData appendData:delimiterData];
             [headerData appendData:contentHeaderData];
@@ -146,7 +150,7 @@
     if (currentStream == nil)
         return 0;
     
-    int result = [currentStream read:buffer maxLength:len];
+    NSInteger result = [currentStream read:buffer maxLength:len];
     
     if (result == 0) {
         if (streamIndex < contentStreams.count - 1) {


### PR DESCRIPTION
type mismatch caused implicit conversion warnings on 64-bit devices
changed types to match what is needed for return value, etc.
