### PR TITLE
Fix non-standard invalid_token header detection

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -470,8 +470,16 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
                 }
             }
             if (authenticateHeader
-                && [authenticateHeader rangeOfString:@"invalid_token"].location != NSNotFound) {
-                client.accessToken = nil;
+                && [authenticateHeader rangeOfString:@"invalid_grant"].location != NSNotFound) {
+                
+                // Try to refresh the token if possible, otherwise remove this account.
+                if (client.accessToken.refreshToken) {
+                    [self cancel];
+                    [client refreshAccessTokenAndRetryConnection:self];
+                    return;
+                } else {
+                    client.accessToken = nil;
+                }
             }
         }
         

--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -470,7 +470,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
                 }
             }
             if (authenticateHeader
-                && [authenticateHeader rangeOfString:@"invalid_grant"].location != NSNotFound) {
+                && ([authenticateHeader rangeOfString:@"invalid_token"].location != NSNotFound || [authenticateHeader rangeOfString:@"invalid_grant"].location != NSNotFound)) {
                 
                 // Try to refresh the token if possible, otherwise remove this account.
                 if (client.accessToken.refreshToken) {


### PR DESCRIPTION
This PR fixes a problem where the header of Www-authenticate was checked with a non-standard keyword for invalid token. Per the RFC, the standard keyword **invalid_grant** specify an invalid or expired token.

Moreover it has been added a check to try to refresh the token if possible.
