### PR TITLE
Fixed bug where client delegate wasn't reassigned to account

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Account.m
+++ b/Sources/OAuth2Client/NXOAuth2Account.m
@@ -49,6 +49,7 @@ NSString * const NXOAuth2AccountDidFailToGetAccessTokenNotification = @"NXOAuth2
                                 accountType:anAccountType];
     if (self) {
         oauthClient = anOAuthClient;
+        oauthClient.delegate = self;
     }
     return self;
 }


### PR DESCRIPTION
When the NXOAuth2Client is created in NXOAuth2AccountStore and passed to initAccountWithOAuthClient of NXOAuth2Account, the delegate wasn't reassigned to the account because oauthClient is nil when initAccountWithAccessToken is called.

On a side note, I believe `oauthClient.delegate = self;` in `initAccountWithAccessToken` could be removed, as `oauthClient` will always be `nil` since the object was just allocated.
