### PR TITLE
Store delegates as weak if available

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Client.h
+++ b/Sources/OAuth2Client/NXOAuth2Client.h
@@ -57,7 +57,11 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
     NSInteger        refreshConnectionDidRetryCount;
     
     // delegates
+#if __has_feature(objc_arc_weak)
+    NSObject<NXOAuth2ClientDelegate>*    __weak delegate;
+#else
     NSObject<NXOAuth2ClientDelegate>*    __unsafe_unretained delegate;    // assigned
+#endif
 }
 
 @property (nonatomic, readonly, getter = isAuthenticating) BOOL authenticating;
@@ -74,7 +78,12 @@ extern NSString * const NXOAuth2ClientConnectionContextTokenRefresh;
 @property (nonatomic, copy) NSString *acceptType; // defaults to application/json
 
 @property (nonatomic, strong) NXOAuth2AccessToken    *accessToken;
-@property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ClientDelegate>*    delegate;
+
+#if __has_feature(objc_arc_weak)
+    @property (nonatomic, weak) NSObject<NXOAuth2ClientDelegate>*    delegate;
+#else
+    @property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ClientDelegate>*    delegate;
+#endif
 
 @property (nonatomic, readonly) NXOAuth2Connection *authConnection;
 

--- a/Sources/OAuth2Client/NXOAuth2Connection.h
+++ b/Sources/OAuth2Client/NXOAuth2Connection.h
@@ -65,7 +65,11 @@ typedef void(^NXOAuth2ConnectionSendingProgressHandler)(unsigned long long bytes
     
     NXOAuth2Client        *client;
     
+#if __has_feature(objc_arc_weak)
+    NSObject<NXOAuth2ConnectionDelegate>    *__weak delegate;
+#else
     NSObject<NXOAuth2ConnectionDelegate>    *__unsafe_unretained delegate;    // assigned
+#endif
     
     NXOAuth2ConnectionResponseHandler responseHandler;
     NXOAuth2ConnectionSendingProgressHandler sendingProgressHandler;
@@ -77,7 +81,12 @@ typedef void(^NXOAuth2ConnectionSendingProgressHandler)(unsigned long long bytes
 #endif
 }
 
-@property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ConnectionDelegate>    *delegate;
+#if __has_feature(objc_arc_weak)
+    @property (nonatomic, weak) NSObject<NXOAuth2ConnectionDelegate>    *delegate;
+#else
+    @property (nonatomic, unsafe_unretained) NSObject<NXOAuth2ConnectionDelegate>    *delegate;
+#endif
+
 @property (nonatomic, strong, readonly) NSData *data;
 @property (nonatomic, assign) BOOL savesData;
 @property (nonatomic, assign, readonly) long long expectedContentLength;


### PR DESCRIPTION
Store delegates as weak to prevent against holding on to a pointer to a deallocated delegate.
