### PR TITLE
Bugfix for Fitbit OAuth problem

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -158,7 +158,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
 - (NSURLConnection *)createConnection;
 {
     // if the request is a token refresh request don't sign it and don't check for the expiration of the token (we know that already)
-    NSString *oauthAuthorizationHeader = nil;
+    NSString *oauthAuthorizationHeader = request.allHTTPHeaderFields[@"Authorization"];
     if (client.accessToken &&
         ![[requestParameters objectForKey:@"grant_type"] isEqualToString:@"refresh_token"]) {
         


### PR DESCRIPTION
Fitbit OAuth2 flow requires authorization headers for all requests. Currently, OAuth2Client doesn't sign all requests and also doesn't use custom headers being provided. 

This fix is backwards compatible and doesn't change behavior unless custom headers have been set.
