### PR TITLE
Fix dropped 401 response when token present

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -424,7 +424,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
     {
         [self cancel];
         [client refreshAccessTokenAndRetryConnection:self];
-    } else if (client.authConnection != self && authenticateHeader && client) {
+    } else if (client.authConnection != self && authenticateHeader && client && !client.accessToken) {
         [self cancel];
         [client requestAccessAndRetryConnection:self];
     } else {


### PR DESCRIPTION
When a 401 response comes back to a request made with a token, if the `WWW-Authenticate` header does not contain the keywords `invalid_token` or `expired_token`, the connection will get dropped silently because `- requestAccessAndRetryConnection:` expects no tokens.

This fix adds an extra condition to ensure that it doesn't attempt to request access when the OAuth2Client's access token is present. The connection won't get dropped and the response handler will be called.
