### PR TITLE
Add an explicit cast to long in format specifier

### DIFF
--- a/Sources/OAuth2Client/NXOAuth2Connection.m
+++ b/Sources/OAuth2Client/NXOAuth2Connection.m
@@ -487,7 +487,7 @@ sendingProgressHandler:(NXOAuth2ConnectionSendingProgressHandler)aSendingProgres
             }
         }
         
-        NSString *localizedError = [NSString stringWithFormat:NSLocalizedString(@"HTTP Error: %d", @"NXOAuth2HTTPErrorDomain description"), self.statusCode];
+        NSString *localizedError = [NSString stringWithFormat:NSLocalizedString(@"HTTP Error: %ld", @"NXOAuth2HTTPErrorDomain description"), (long)self.statusCode];
         NSDictionary *errorUserInfo = [NSDictionary dictionaryWithObject:localizedError forKey:NSLocalizedDescriptionKey];
         NSError *error = [NSError errorWithDomain:NXOAuth2HTTPErrorDomain
                                              code:self.statusCode


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html
suggests an explicit cast to 'long' for 32/64 bit compatibility, since on 32 bit NSInteger is int/ unsigned int and
on 64bit architectures it's long/unsigned long.

New versions of clang will complain about this with following warning:
Sources/OAuth2Client/NXOAuth2Connection.m:478:141: error: values of type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead [-Werror,-Wformat]
        NSString *localizedError = [NSString stringWithFormat:NSLocalizedString(@"HTTP Error: %d", @"NXOAuth2HTTPErrorDomain description"), self.statusCode];
                                                                                              ~~                                            ^~~~~~~~~~~~~~~
                                                                                              %ld                                           (long)
1 error generated.